### PR TITLE
Fix/examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .idea
 build
-dist
+lib

--- a/examples/usage.es5.js
+++ b/examples/usage.es5.js
@@ -1,5 +1,4 @@
-const DashJS = require("../src");
-console.log(DashJS)
+const DashJS = require("../lib/dash.min.js");
 const schema = require("./schema.json");
 
 const network = "testnet";
@@ -10,12 +9,14 @@ const opts = {
 };
 const sdk = new DashJS.SDK(opts);
 const acc = sdk.wallet.getAccount();
+readDocument();
+
 async function sendPayment(){
   const tx = await acc.createTransaction({recipient:{address:'yLptqWxjgTxtwKJuLHoGY222NnoeqYuN8h', amount:0.12}})
   console.log(tx)
 }
 
 async function readDocument() {
-  const profile = await sdk.platform.fetchDocuments('profile', {}, opts)
+  const profile = await sdk.platform.documents.fetch('profile', opts);
   console.log(profile);
 }

--- a/examples/usage.es6.ts
+++ b/examples/usage.es6.ts
@@ -10,12 +10,14 @@ const opts: SDKOpts = {
 };
 const sdk = new DashJS.SDK(opts);
 const acc = sdk.wallet.getAccount();
+readDocument();
+
 async function sendPayment(){
     const tx = await acc.createTransaction({recipient:{address:'yLptqWxjgTxtwKJuLHoGY222NnoeqYuN8h', amount:0.12}})
     console.log(tx)
 }
 
 async function readDocument() {
-    const profile = await sdk.platform.fetchDocuments('profile',  opts)
+    const profile = await sdk.platform.documents.fetch('profile',  opts)
     console.log(profile);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,23 @@
         "axios": "^0.19.0",
         "lodash": "^4.17.11",
         "lowdb": "^1.0.0"
+      },
+      "dependencies": {
+        "@dashevo/dashcore-lib": {
+          "version": "0.17.12",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
+          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
+          "requires": {
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
+          }
+        }
       }
     },
     "@dashevo/dapi-grpc": {
@@ -54,6 +71,23 @@
         "@dashevo/dashcore-lib": "^0.17.4",
         "levelup": "^4.0.1",
         "memdown": "^3.0.0"
+      },
+      "dependencies": {
+        "@dashevo/dashcore-lib": {
+          "version": "0.17.12",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
+          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
+          "requires": {
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
+          }
+        }
       }
     },
     "@dashevo/dash-util": {
@@ -93,6 +127,23 @@
         "lodash.mergewith": "^4.6.2",
         "lodash.set": "^4.3.2",
         "multihashes": "^0.4.13"
+      },
+      "dependencies": {
+        "@dashevo/dashcore-lib": {
+          "version": "0.17.12",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
+          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
+          "requires": {
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
+          }
+        }
       }
     },
     "@dashevo/grpc-common": {
@@ -144,6 +195,21 @@
             "grpc-web": "^1.0.5",
             "lodash.snakecase": "^4.1.1",
             "protobufjs": "^6.8.8"
+          }
+        },
+        "@dashevo/dashcore-lib": {
+          "version": "0.17.12",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
+          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
+          "requires": {
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
           }
         },
         "@dashevo/dpp": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "allowJs": true,
     "sourceMap": true
   },
-  "exclude": ["node_modules", "**/*.test.ts", "examples", "tests", "dist"],
+  "exclude": ["node_modules", "**/*.test.ts", "examples", "tests", "lib"],
   "typeRoots": ["node_modules/@types", "./typings"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,8 @@ module.exports = {
         extensions: ['.ts', '.js', '.json'],
     },
     output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'dist'),
+        filename: 'dash.min.js',
+        path: path.resolve(__dirname, 'lib'),
     },
     plugins: [
         // new BundleAnalyzerPlugin(),


### PR DESCRIPTION
### Issue being fixed or implemented  

Library bundle has a nonstandard location and filename.

### What was done  

Change WebPack output from `dist/bundle.js` to `lib/dash.min.js`.
Change references to `dist` to `lib`.
Fix `examples/usage.es5.js` to refer to `lib/dash.min.js` instead of `src/index.ts`.

### How Has This Been Tested?

- [x] I ran the `build:dev` script and confirmed the bundle is recreated in the right location.
- [x] I ran `node examples/usage.es5.js` and got the same output (error) that I got before making this change

### Notes  


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] (N/A) I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
