### PR TITLE
docs: update @dashevo/dashjs references to dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DashJS
 
-[![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/@dashevo/dashjs)
+[![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/dash)
 [![Build Status](https://img.shields.io/travis/com/dashevo/dashjs.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/dashjs)
 
 > Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)
@@ -18,10 +18,10 @@ Find more in the :
 
 In order to use this library, you will need to add it to your project as a dependency.
 
-Having [NodeJS](https://nodejs.org/) installed, just type : `npm install @dashevo/dashjs` in your terminal.
+Having [NodeJS](https://nodejs.org/) installed, just type : `npm install dash` in your terminal.
 
 ```sh
-npm install @dashevo/dashjs
+npm install dash
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For browser usage, you can also directly rely on unpkg :
 ## Usage
 
 ```js
-import DashJS from "@dashevo/dashjs"; 
+import DashJS from "dash"; 
 import schema from "./schema.json";
 
 const network = "testnet";

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## DashJS
 
-[![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/@dashevo/dashjs)
+[![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/dash)
 [![Build Status](https://img.shields.io/travis/com/dashevo/dashjs.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/dashjs)
 
 > Client-side library for wallet payment/signing and application development with Dash. (Wallet, DAPI, Primitives, BLS, ...)
@@ -12,12 +12,12 @@ DashJS is intended to provide in a single entry-point all the different feature 
 
 ### Install
 
-In order to use this library, you will need to add our [NPM package](https://www.npmjs.com/@dashevo/dashjs) to your project.
+In order to use this library, you will need to add our [NPM package](https://www.npmjs.com/dash) to your project.
 
 Having [NodeJS](https://nodejs.org/) installed, just type :
 
 ```bash
-npm install @dashevo/dashjs
+npm install dash
 ```
 
 ## Licence

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,11 +1,11 @@
 # Quick start
 
-In order to use this library, you will need to add our [NPM package](https://www.npmjs.com/@dashevo/dashjs) to your project.
+In order to use this library, you will need to add our [NPM package](https://www.npmjs.com/dash) to your project.
 
 Having [NodeJS](https://nodejs.org/) installed, just type :
 
 ```bash
-npm install @dashevo/dashjs
+npm install dash
 ## Initialize
 ```
 ## Initialization

--- a/docs/usage/dashcorelib-primitives.md
+++ b/docs/usage/dashcorelib-primitives.md
@@ -3,7 +3,7 @@
 The Transaction primitive allows easy creation and manipulation of transactions. It also allows signing when provided with a privatekey.  
 Supports fee control and input/output access (which allows passing a specific script).
 ```js
-import { Transaction } from '@dashevo/dashjs';
+import { Transaction } from 'dash';
 const tx = new Transaction(txProps)
 ```
 
@@ -15,7 +15,7 @@ Standardized representation of a Dash Address. Address can be instantiated from 
 Pay-to-script-hash (P2SH) multi-signature addresses from an array of PublicKeys are also supported.  
 
 ```js
-import { Address } from '@dashevo/dashjs';
+import { Address } from 'dash';
 ```
 
 Access the [Address documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/address.md)
@@ -26,7 +26,7 @@ Given a hexadecimal string representation of the block as input, the Block class
 
 Transactions of the block can also be explored by iterating over elements in array (`block.transactions`).  
 
-`import { Block } from '@dashevo/dashjs'`
+`import { Block } from 'dash'`
 
 Access the [Block documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/block.md)
 
@@ -35,7 +35,7 @@ Access the [Block documentation on dashevo/dashcore-lib](https://github.com/dash
 Representation of an UnspentOutput (also called UTXO as in Unspent Transaction Output).  
 Mostly useful in association with a Transaction and for Scripts. 
 
-`import { UnspentOutput } from '@dashevo/dashjs'`
+`import { UnspentOutput } from 'dash'`
 
 Access the [UnspentOutput documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/unspentoutput.md)
 
@@ -44,7 +44,7 @@ Access the [UnspentOutput documentation on dashevo/dashcore-lib](https://github.
 Hierarchical Deterministic (HD) version of the PublicKey.  
 Used internally by Wallet-lib and for exchange between peers (DashPay)
 
-`import { HDPublicKey } from '@dashevo/dashjs'`
+`import { HDPublicKey } from 'dash'`
 
 Access the [HDKeys documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/hierarchical.md)
 
@@ -53,19 +53,19 @@ Access the [HDKeys documentation on dashevo/dashcore-lib](https://github.com/das
 Hierarchical Deterministic (HD) version of the PrivateKey.  
 Used internally by Wallet-lib.
 
-`import { HDPrivateKey } from '@dashevo/dashjs'`
+`import { HDPrivateKey } from 'dash'`
 
 Access the [HDKeys documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/hierarchical.md)
 
 ## PublicKey
 
-`import { PublicKey } from '@dashevo/dashjs'`
+`import { PublicKey } from 'dash'`
 
 Access the [PublicKey documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/publickey.md)
 
 ## PrivateKey
 
-`import { PrivateKey } from '@dashevo/dashjs'`
+`import { PrivateKey } from 'dash'`
 
 Access the [PrivateKey documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/privatekey.md)
 
@@ -74,7 +74,7 @@ Access the [PrivateKey documentation on dashevo/dashcore-lib](https://github.com
 Implementation of [BIP39 Mnemonic code for generative deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).  
 Allow to generate random mnemonic on the language set needed, validate a mnemonic or get the HDPrivateKey associated.  
 
-`import { Mnemonic } from '@dashevo/dashjs'`
+`import { Mnemonic } from 'dash'`
 
 Access the [Mnemonic documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/mnemonic.md)
 
@@ -82,7 +82,7 @@ Access the [Mnemonic documentation on dashevo/dashcore-lib](https://github.com/d
 
 A representation of the internal parameters relative to the network used. By default, all primitives works with 'livenet', this class allow to have an testnet instance to used on the other primitives (such as Addresses), or for Wallet-lib.
 
-`import { Network } from '@dashevo/dashjs'`
+`import { Network } from 'dash'`
 
 
 Access the [Network documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/networks.md)
@@ -95,20 +95,20 @@ A valid Transaction is a transaction which output script are evaluated as valid.
 Some operations of this language, such as OP_RETURN has been used to store hashes and B64 data on the payment chain.  
 Learn more on our walkthrough [Transaction script manipulation with the OP_RETURN example](/docs/walkthroughs/op_return/or_return.md)
 
-`import { Script } from '@dashevo/dashjs'`
+`import { Script } from 'dash'`
 
 Access the [Script documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/script.md)
 
 
 ## Input
 
-`import { Input } from '@dashevo/dashjs'`
+`import { Input } from 'dash'`
 
 Access the [Transaction documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/transaction.md)
 
 
 ## Output
 
-`import { Output } from '@dashevo/dashjs'`
+`import { Output } from 'dash'`
 
 Access the [Transaction documentation on dashevo/dashcore-lib](https://github.com/dashevo/dashcore-lib/blob/master/docs/transaction.md)


### PR DESCRIPTION
### Issue being fixed or implemented  

Several references to @dashevo/dashjs remain in places that should just be "dash"

### What was done  

Updated readme to remove incorrect references

### How Has This Been Tested?

N/A

### Notes  


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
