### PR TITLE
Update Node versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: linux
 language: node_js
 node_js:
-  - '8'
   - "10"
   - "12"
 

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -4,7 +4,7 @@ set -xe
 
 # Update this whenever the latest Node.js LTS version changes (~ every year).
 # Do not forget to add this version to .travis.yml config also.
-LATEST_LTS_VERSION="10"
+LATEST_LTS_VERSION="12"
 
 # We want this command to succeed whether or not the Node.js version is the
 # latest (so that the build does not show as failed), but _only_ the latest


### PR DESCRIPTION
Node version 8 reaches End-of-Life on 31st December (tomorrow). Both 10 and 12 are Active LTS 'til April 2021.

Also bump latest Node LTS version -- this would affect the deploy, using v12 instead of v10 to deploy. @Alex-Werner let me know if you want to discuss supporting _lowest_ instead of highest Node LTS version. I can also split this into a separate PR if you prefer.