### PR TITLE
fix(Identity): .register was not applying ST

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "dist/dash.cjs.min.js",
   "unpkg": "dist/dash.min.js",

--- a/src/DashJS/SDK/Platform/methods/identities/register.ts
+++ b/src/DashJS/SDK/Platform/methods/identities/register.ts
@@ -10,7 +10,7 @@ const IdentityCreateTransition = require('@dashevo/dpp/lib/identity/stateTransit
 import {Platform} from "../../Platform";
 
 export async function register(this: Platform, identityType: string = 'USER'): Promise<any> {
-    const { account } = this;
+    const { account, client } = this;
 
     const burnAmount = 10000;
 
@@ -109,6 +109,9 @@ export async function register(this: Platform, identityType: string = 'USER'): P
         // FIXME : Need dpp to be a dependency of wallet-lib to deal with signing IdentityPublicKey (validation)
         // account.sign(identityPublicKeyModel, identityPrivateKey);
         identityCreateTransition.sign(identityPublicKeyModel, identityPrivateKey);
+
+        // @ts-ignore
+        await client.applyStateTransition(identityCreateTransition);
 
         // @ts-ignore
         return identityCreateTransition.getIdentityId();


### PR DESCRIPTION
### Issue being fixed or implemented  

When using `platform.identity.register()`, the locktx was being broadcasted, the ST prepared but not broadcasted. 
This resolves that failing process. 

### What was done  

- Call client.applyStateTransition to send our prepare ST to the state machine.  

### How Has This Been Tested?

- Registered `AaGHAQaCNqvJdeJFtVByc8Pa8bTAM1YGKHnG7Sjsh6nq` and fetch-it back worked as intended.

### Notes  

Thanks to @Antti-Kaikkonen for reporting and helping fixing the bug !

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
