### PR TITLE
chore: Enable tag based deploy pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: linux
 language: node_js
+
+# Support Active LTS versions of Node.js
 node_js:
   - "10"
   - "12"
@@ -7,8 +9,15 @@ node_js:
 before_install:
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
+install:
+  - npm ci
+
 after_install:
   - npm run build:prod
+
+script:
+  - npm run check-package
+  - npm run test
 
 deploy:
   - provider: script
@@ -16,4 +25,4 @@ deploy:
     script: bash scripts/travis-deploy.sh
     on:
       repo: dashevo/DashJS
-      branch: master
+      tags: true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start:dev": "nodemon --exec 'npm run build:dev && npm run test:ts'",
     "build:dev": "webpack -d --display-error-details --progress",
     "build:prod": "webpack -p --display-error-details --progress",
+    "check-package": "npm run check-package:name && npm run check-package:version",
+    "check-package:name": "test $(jq -r .name package.json) = $(jq -r .name package-lock.json)",
+    "check-package:version": "test $(jq -r .version package.json) = $(jq -r .version package-lock.json)",
     "test": "npm run test:ts && npm run build:prod && npm run test:js",
     "test:ts": "mocha -r ts-node/register \"src/**/*.spec.ts\"",
     "test:js": "mocha --recursive tests/**/*.js"

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -14,8 +14,18 @@ if [ "$TRAVIS_NODE_VERSION" != "$LATEST_LTS_VERSION" ]; then
   exit 0
 fi
 
-# Should be done already by .travis.yml
-# npm run build:prod
+# Ensure the tag matches the one in package.json, otherwise abort.
+PACKAGE_TAG=v"$(jq -r .version package.json)"
+if [ "$PACKAGE_TAG" != "$TRAVIS_TAG" ]; then
+  echo "Travis tag (\"$TRAVIS_TAG\") is not equal to package.json tag (\"$PACKAGE_TAG\"). Please push a correct tag and try again."
+  exit 1
+fi
+
+# Use regex pattern matching to check if "dev" exists in tag
+NPM_TAG="latest"
+if [[ $PACKAGE_TAG =~ dev ]]; then
+  NPM_TAG="dev"
+fi
 
 # Now that checks have been passed, publish the module
-npm publish
+npm publish --tag $NPM_TAG


### PR DESCRIPTION
This does several things:

- Install dependencies via `npm ci`
- Add check-package scripts to ensure same values for both name and version in `package.json` and `package-lock.json`
- Set Travis config to only deploy on tags, and only for this repo (not forks, for example)
- Update deploy script to check tags. The first check `$PACKAGE_TAG" != "$TRAVIS_TAG"` makes sure the tag version number pushed via `git` is equal to the version number in `package.json`. It should be "v1.2.3" for example, for the tag, and "1.2.3" in the package.json version.

It also checks if the string "dev" exists in the tag in order to not use "latest" for a dev tag. Then it publishes the module to npm with a tag of either `latest` or `dev`.