### PR TITLE
chore: Use latest Travis dist bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-os: linux
+dist: bionic
 language: node_js
 
 # Support Active LTS versions of Node.js


### PR DESCRIPTION
Based on #18 , will rebase if / when that gets merged. Currently that is running on xenial by default.