### PR TITLE
doc: Fix incorrect docsify links in_sidebar.md

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -42,10 +42,9 @@
             - [`.create()`](platform/contracts/create.md)
             - [`.broadcast()`](platform/contracts/broadcast.md)
         - **Documents**
-            - [About contracts](platform/contracts/about-contracts.md)
-            - [`.get()`](platform/contracts/get.md)
-            - [`.create()`](platform/contracts/create.md)
-            - [`.broadcast()`](platform/contracts/broadcast.md)
+            - [`.get()`](platform/documents/get.md)
+            - [`.create()`](platform/documents/create.md)
+            - [`.broadcast()`](platform/documents/broadcast.md)
         - **Names**
             - [About DPNS](platform/names/about-dpns.md)
             - [`.get()`](platform/names/get.md)


### PR DESCRIPTION
### Issue being fixed or implemented  
The documents-related links were going to the contract documents

### What was done  
Fixed links

### How Has This Been Tested?
- [x] Verified links go to existing documents

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
