### PR TITLE
fix(DPNS): error handling & type locator

### DIFF
--- a/src/DashJS/SDK/Platform/Platform.ts
+++ b/src/DashJS/SDK/Platform/Platform.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import DashPlatformProtocol from "@dashevo/dpp";
-import {Mnemonic, Network} from "@dashevo/wallet-lib/src/types/types";
 // @ts-ignore
 import DAPIClient from "@dashevo/dapi-client"
 import {SDKClients, SDKApps} from "../SDK";
@@ -20,6 +19,7 @@ import registerIdentity from "./methods/identities/register";
 import getName from "./methods/names/get";
 import registerName from "./methods/names/register";
 
+// @ts-ignore
 import {Account} from "@dashevo/wallet-lib";
 
 export interface PlatformOpts {

--- a/src/DashJS/SDK/Platform/methods/contracts/get.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/get.ts
@@ -27,7 +27,7 @@ export async function get(this: Platform, identifier: ContractIdentifier): Promi
             }
             return app.contract;
         } catch (e) {
-            console.error('failed to getDataContract', e);
+            console.error('Failed to get dataContract', e);
             throw e;
         }
 

--- a/src/DashJS/SDK/Platform/methods/contracts/get.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/get.ts
@@ -16,15 +16,21 @@ export async function get(this: Platform, identifier: ContractIdentifier): Promi
     if (localContract && localContract.contract) {
         return localContract.contract;
     } else {
-        // @ts-ignore
-        const rawContract = await this.client.getDataContract(identifier)
-        const contract = this.dpp.dataContract.createFromSerialized(rawContract);
-        const app = {contractId: identifier, contract};
-        // If we do not have even the identifier in this.apps, we add it with timestamp as key
-        if (localContract === undefined) {
-            this.apps[Date.now()] = app
+        try {
+            // @ts-ignore
+            const rawContract = await this.client.getDataContract(identifier)
+            const contract = this.dpp.dataContract.createFromSerialized(rawContract);
+            const app = {contractId: identifier, contract};
+            // If we do not have even the identifier in this.apps, we add it with timestamp as key
+            if (localContract === undefined) {
+                this.apps[Date.now()] = app
+            }
+            return app.contract;
+        } catch (e) {
+            console.error('failed to getDataContract', e);
+            throw e;
         }
-        return app.contract;
+
     }
 }
 

--- a/src/DashJS/SDK/Platform/methods/documents/create.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/create.ts
@@ -4,11 +4,10 @@ declare interface createOpts {
     [name:string]: any;
 }
 
-export function create(this: Platform, typeLocator: string, identity: any, opts: createOpts): any {
+export async function create(this: Platform, typeLocator: string, identity: any, opts: createOpts): Promise<any> {
     const {  dpp } = this;
 
     const appNames = Object.keys(this.apps);
-
     //We can either provide of type `dashpay.profile` or if only one schema provided, of type `profile`.
     const [appName, fieldType] = (typeLocator.includes('.')) ? typeLocator.split('.') : [appNames[0], typeLocator];
 
@@ -16,7 +15,7 @@ export function create(this: Platform, typeLocator: string, identity: any, opts:
     if(!this.apps[appName] || !this.apps[appName]){
         throw new Error(`Cannot find contractId for ${appName}`);
     }
-    const dataContract = this.contracts.get(this.apps[appName].contractId);
+    const dataContract = await this.contracts.get(this.apps[appName].contractId);
     return dpp.document.create(
         dataContract,
         identity.getId(),

--- a/src/DashJS/SDK/Platform/methods/documents/create.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/create.ts
@@ -5,7 +5,7 @@ declare interface createOpts {
 }
 
 export async function create(this: Platform, typeLocator: string, identity: any, opts: createOpts): Promise<any> {
-    const {  dpp } = this;
+    const { dpp } = this;
 
     const appNames = Object.keys(this.apps);
     //We can either provide of type `dashpay.profile` or if only one schema provided, of type `profile`.

--- a/src/DashJS/SDK/Platform/methods/documents/get.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/get.ts
@@ -29,11 +29,16 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
         const documents: any[] = [];
 
         for (const rawData of rawDataList) {
-            documents.push(await this.dpp.document.createFromSerialized(rawData, {skipValidation: true}));
+            try{
+                const doc = await this.dpp.document.createFromSerialized(rawData, {skipValidation: true})
+                documents.push(doc);
+            }catch (e) {
+                console.error('Document creation: failure', e);
+            }
         }
         return documents
     }catch (e) {
-        console.error(`Failing getting documents of ${contractId}`);
+        console.error(`Document creation: unable to get documents of ${contractId}`);
         throw e;
     }
 }

--- a/src/DashJS/SDK/Platform/methods/documents/get.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/get.ts
@@ -29,15 +29,15 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
         const documents: any[] = [];
 
         for (const rawData of rawDataList) {
-            try{
+            try {
                 const doc = await this.dpp.document.createFromSerialized(rawData, {skipValidation: true})
                 documents.push(doc);
-            }catch (e) {
+            } catch (e) {
                 console.error('Document creation: failure', e);
             }
         }
         return documents
-    }catch (e) {
+    } catch (e) {
         console.error(`Document creation: unable to get documents of ${contractId}`);
         throw e;
     }

--- a/src/DashJS/SDK/Platform/methods/names/register.ts
+++ b/src/DashJS/SDK/Platform/methods/names/register.ts
@@ -45,15 +45,10 @@ export async function register(this: Platform,
     if(!this.apps.dpns.contractId){
         throw new Error('DPNS is required to register a new name.');
     }
-    const dataContract = await this.contracts.get(this.apps.dpns.contractId);
-    if(!dataContract){
-        throw new Error('DPNS Contract not loaded. Cannot register.');
-    }
     // 1. Create preorder document
-    const preorderDocument = dpp.document.create(
-        dataContract,
-        identity.id,
+    const preorderDocument = this.documents.create(
         'dpns.preorder',
+        identity,
         {
             saltedDomainHash,
         },
@@ -66,10 +61,9 @@ export async function register(this: Platform,
     await client.applyStateTransition(preorderTransition);
 
     // 3. Create domain document
-    const domainDocument = dpp.document.create(
-        dataContract,
-        identity.id,
+    const domainDocument = this.documents.create(
         'dpns.domain',
+        identity,
         {
             nameHash,
             label,

--- a/src/DashJS/SDK/Platform/methods/names/register.ts
+++ b/src/DashJS/SDK/Platform/methods/names/register.ts
@@ -53,7 +53,7 @@ export async function register(this: Platform,
     const preorderDocument = dpp.document.create(
         dataContract,
         identity.id,
-        'preorder',
+        'dpns.preorder',
         {
             saltedDomainHash,
         },
@@ -69,7 +69,7 @@ export async function register(this: Platform,
     const domainDocument = dpp.document.create(
         dataContract,
         identity.id,
-        'domain',
+        'dpns.domain',
         {
             nameHash,
             label,

--- a/src/DashJS/SDK/Platform/methods/names/register.ts
+++ b/src/DashJS/SDK/Platform/methods/names/register.ts
@@ -46,7 +46,7 @@ export async function register(this: Platform,
         throw new Error('DPNS is required to register a new name.');
     }
     // 1. Create preorder document
-    const preorderDocument = this.documents.create(
+    const preorderDocument = await this.documents.create(
         'dpns.preorder',
         identity,
         {
@@ -61,7 +61,7 @@ export async function register(this: Platform,
     await client.applyStateTransition(preorderTransition);
 
     // 3. Create domain document
-    const domainDocument = this.documents.create(
+    const domainDocument = await this.documents.create(
         'dpns.domain',
         identity,
         {

--- a/src/DashJS/SDK/SDK.ts
+++ b/src/DashJS/SDK/SDK.ts
@@ -63,7 +63,7 @@ export class SDK {
             isReady: false,
             isAccountReady: false
         };
-        const seeds = (opts.seeds)? opts.seeds : defaultSeeds;
+        const seeds = (opts.seeds) ? opts.seeds : defaultSeeds;
 
         this.clients = {
             dapi: new DAPIClient({
@@ -108,22 +108,23 @@ export class SDK {
         const promises = [];
         for (let appName in this.apps) {
             const app = this.apps[appName];
-            try {
-                const p = this.platform?.contracts.get(app.contractId);
-                promises.push(p);
-            } catch (e) {
-                console.error(e);
-            }
+            const p = this.platform?.contracts.get(app.contractId);
+            promises.push(p);
         }
         Promise
             .all(promises)
-            .then((res) => {this.state.isReady = true});
+            .then((res) => {
+                this.state.isReady = true
+            })
+            .catch((e) => {
+                console.error('SDK apps fetching : failed to init', e);
+            });
+
     }
 
 
-
-   async disconnect(){
-        if(this.wallet){
+    async disconnect() {
+        if (this.wallet) {
             await this.wallet.disconnect();
         }
     }

--- a/tests/z_integrations/user-flow-1.js
+++ b/tests/z_integrations/user-flow-1.js
@@ -40,7 +40,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
   it('should be ready quickly', (done) => {
     let timer = setTimeout(() => {
       done(new Error('Should have been initialized in time'));
-    }, 5000);
+    }, 15000);
     sdkInstance.isReady().then(() => {
       clearTimeout(timer);
       expect(sdkInstance.account.state).to.deep.equal({isInitialized: true, isReady: true, isDisconnecting: false});
@@ -102,6 +102,9 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
   });
 
   it('should retrieve itself by document', async function () {
+    if(!createdIdentity){
+      throw new Error('Can\'t perform the test. Failed to fetch identity & did not reg name');
+    }
     const [doc] = await sdkInstance.platform.documents.get('dpns.domain', {where:[
         ["normalizedParentDomainName","==","dash"],
         ["normalizedLabel","==",username.toLowerCase()],


### PR DESCRIPTION
### Issue being fixed or implemented  

If we were to manage multiples apps with an updated dpns (with another order than [0]), creating a new names would have failed to find `domain` and `preorder` from the schema.

### What was done  

- Fix the issue by passing it the expected locator (`dpns.`)
- Impr: error handling on fetching contracts & documents

### How Has This Been Tested?

Using current test suite. 

### Notes  


### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
