### PR TITLE
feat(names): Accept qualified names like evan.dash in names.register

### DIFF
--- a/docs/platform/names/register.md
+++ b/docs/platform/names/register.md
@@ -5,7 +5,7 @@ Parameters:
 
 | parameters                | type      | required       | Description                                                                   |  
 |---------------------------|-----------|----------------| ----------------------------------------------------------------------------- |
-| **name**                  | String    | yes            | An alphanumeric (2-63) value used for human-identification (can contains `-`) |
+| **name**                  | String    | yes            | An alphanumeric (1-63 character) value used for human-identification (can contain `-` but not as the first or last character). If a name with no parent domain is entered, '.dash' is used. |
 | **identity**              | Identity  | yes            | A valid [registered identity](/platform/identities/register.md)               |
 
 

--- a/src/DashJS/SDK/Platform/methods/names/register.ts
+++ b/src/DashJS/SDK/Platform/methods/names/register.ts
@@ -22,8 +22,17 @@ export async function register(this: Platform,
 
     const records = {dashIdentity: identity.id};
 
-    const normalizedParentDomainName = `dash`;
-    const label = name;
+    const nameSlice = name.indexOf('.');
+    const normalizedParentDomainName = (
+        nameSlice === -1
+        ? 'dash'
+        : name.slice(nameSlice + 1)
+    );
+    const label = (
+        nameSlice === -1
+        ? name
+        : name.slice(0,nameSlice)
+    );
     const normalizedLabel = label.toLowerCase();
     const fullDomainName = `${normalizedLabel}.${normalizedParentDomainName}`;
 


### PR DESCRIPTION
### Issue being fixed or implemented

`sdk.platform.names.register` has a `names` parameter. Before this change, it only accepted labels, and the only parent domain that could be used is `.dash`. This makes `names.register` more flexible, giving the same behavior as before, but also accepting names like `a.b.dash` or `a.b.other` if other TLDs are registered.

### What was done  

`sdk.platform.names.register` now splits the `name` parameter at the first period if it exists, and if not it falls back on the original behavior.

### How Has This Been Tested?

I altered the example node scripts to reference the un-compiled source files, then registered a variety of names successfully.

### Notes  


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
