### PR TITLE
fix: restrict to working dpp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@dashevo/dapi-client": "^0.8.0-dev.14",
     "@dashevo/dashcore-lib": "^0.18.0",
-    "@dashevo/dpp": "^0.10.0-dev.14",
+    "@dashevo/dpp": "0.10.0-dev.14",
     "@dashevo/wallet-lib": "5.0.3",
     "bs58": "^4.0.1"
   },


### PR DESCRIPTION
@Alex-Werner Not sure this is how you want to handle this, but it appears to work.

### Issue being fixed or implemented  

Fix for DPNS name registration failure (#26). It appears that a change in js-dpp 0.10.0-dev.15 introduced something incompatible with current Evonet.

### What was done  

Hold dpp at 0.10.0-dev.14 for now in `package.json`

### How Has This Been Tested?

Reproduced issue locally and tested solution.

### Notes  

Both 0.10.0-dev.15 and 0.10.0 are problematic. When Evonet is updated with those DPP changes, DashJS will have to update at the same time to maintain compatibility.

Closes #26 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
