### PR TITLE
refact: Code cleanup & typing documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,36 +4,38 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/polyfill": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
-      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@dashevo/dapi-client": {
-      "version": "0.8.0-dev.14",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.8.0-dev.14.tgz",
-      "integrity": "sha512-/dgZUDjHUHflxQS/q0N+nPW0LOnqH6PfN5QVwIR/KvJrWqwGlsyZgncVBECXOwvb8tsDPeRWlPgmzKknDHUA3g==",
+      "version": "0.9.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.9.0-dev.6.tgz",
+      "integrity": "sha512-izM1zzp+HDXinQNOx3wIvHiURc80JWJewserwq6ipeLfsAaIIDh6fCN20s/wZ0mLN7THYfR23VwtaMfEkLg1Zw==",
       "requires": {
-        "@babel/polyfill": "^7.2.5",
-        "@dashevo/dapi-grpc": "0.12.0-dev.10",
-        "@dashevo/dash-spv": "^1.1.5",
-        "@dashevo/dashcore-lib": "^0.17.11",
-        "axios": "^0.19.0",
+        "@babel/polyfill": "^7.8.3",
+        "@dashevo/dapi-grpc": "~0.12.1",
+        "@dashevo/dash-spv": "^1.1.6",
+        "@dashevo/dashcore-lib": "~0.18.0",
+        "@dashevo/dpp": "~0.10.1",
+        "axios": "^0.19.2",
         "cbor": "^5.0.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "lowdb": "^1.0.0"
       },
       "dependencies": {
+        "@babel/polyfill": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
+          "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
+          "requires": {
+            "core-js": "^2.6.5",
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "@dashevo/dashcore-lib": {
-          "version": "0.17.12",
-          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.18.0.tgz",
+          "integrity": "sha512-oh+lEdZYbjwY8PVoQBPPXtmtTH0RiT8jAqYXgIEL0krGP+NhwaLhuKzcFLDymfYCloWewMxC8sLpYBoFz98xRw==",
           "requires": {
             "@dashevo/x11-hash-js": "^1.0.2",
+            "@types/node": "^12.12.12",
             "bloom-filter": "^0.2.0",
             "bn.js": "=4.11.8",
             "bs58": "=4.0.1",
@@ -42,13 +44,36 @@
             "lodash": "^4.17.15",
             "unorm": "^1.4.1"
           }
+        },
+        "@dashevo/dpp": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.1.tgz",
+          "integrity": "sha512-IVqat0OIgbC/cU4Hu9BQvC6hchxFWqFZGnkgyRcgH7pk3iN56KJ74FDvnL+qy4onVT+XAbwXEcbITiOZIhkjLA==",
+          "requires": {
+            "@dashevo/dashcore-lib": "0.18.0",
+            "ajv": "^6.10.2",
+            "bs58": "^4.0.1",
+            "cbor": "^5.0.1",
+            "lodash.get": "^4.4.2",
+            "lodash.mergewith": "^4.6.2",
+            "lodash.set": "^4.3.2",
+            "multihashes": "^0.4.15"
+          }
+        },
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
         }
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.12.0-dev.10",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.12.0-dev.10.tgz",
-      "integrity": "sha512-xG06yulY1zCQFv8gBeCXwVthOKWgoPCUq6M/9v+wXZXdS3s3d4LWzQCW3nExpaMOdRuoc5OyrthYUZYWgF8rFw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.12.1.tgz",
+      "integrity": "sha512-pABiI6lGjtoFHy0Y18HFqPAk06gQArxCJgR1YBF2M+wZI3O38PROUkGHVb/29oZGR8sIB/b7siSypnczWmItiA==",
       "requires": {
         "@dashevo/grpc-common": "^0.2.0",
         "google-protobuf": "^3.8.0",
@@ -117,29 +142,35 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.10.0-dev.14",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.14.tgz",
-      "integrity": "sha512-2SWpgkuyFO6010M0Sbq5UjaKc7fjxIslXUSZUg3w+vwUNY4npVVIMdhzD++vHi0fO7ZRbNdX0QESvx5hj/LxeQ==",
+      "version": "0.11.0-dev.4",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.11.0-dev.4.tgz",
+      "integrity": "sha512-IhR/SuqM8p+H8ekaNXpEBV19yEoy/FQfPxFsbf4exGY/oCnDidWkBvvL7kR00csSB8IZNQ9uMU2Wz1az/KcGZQ==",
       "requires": {
-        "@dashevo/dashcore-lib": "0.18.0",
-        "ajv": "^6.5.4",
+        "@dashevo/dashcore-lib": "~0.18.0",
+        "ajv": "^6.10.2",
         "bs58": "^4.0.1",
-        "cbor": "^4.1.1",
+        "cbor": "^5.0.1",
+        "json-schema-ref-parser": "^7.1.3",
         "lodash.get": "^4.4.2",
         "lodash.mergewith": "^4.6.2",
         "lodash.set": "^4.3.2",
-        "multihashes": "^0.4.13"
+        "multihashes": "^0.4.15"
       },
       "dependencies": {
-        "cbor": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
-          "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
+        "@dashevo/dashcore-lib": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.18.0.tgz",
+          "integrity": "sha512-oh+lEdZYbjwY8PVoQBPPXtmtTH0RiT8jAqYXgIEL0krGP+NhwaLhuKzcFLDymfYCloWewMxC8sLpYBoFz98xRw==",
           "requires": {
-            "bignumber.js": "^9.0.0",
-            "commander": "^3.0.0",
-            "json-text-sequence": "^0.1",
-            "nofilter": "^1.0.3"
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "@types/node": "^12.12.12",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
           }
         }
       }
@@ -156,62 +187,33 @@
       }
     },
     "@dashevo/wallet-lib": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-5.0.3.tgz",
-      "integrity": "sha512-RrTDVrLZ2YIhCfw5YiTOyRu8+cFgxYwnEV1EzkZ+sK5lnGtvwD54xzOYf1IPEmRw/SH+KgZ5lU3WK81lySHtvg==",
+      "version": "6.0.0",
+      "resolved": "git+https://github.com/dashevo/wallet-lib.git#e2395361ae8962ea0bff087d0abc0152d7d122c4",
       "requires": {
-        "@dashevo/dapi-client": "^0.7.0",
         "@dashevo/dashcore-lib": "^0.18.0",
-        "@dashevo/dpp": "^0.10.0-dev.14",
+        "@dashevo/dpp": "^0.11.0-dev.4",
         "cbor": "^5.0.1",
-        "crypto-js": "^3.1.9-1",
-        "localforage": "^1.7.3",
+        "crypto-js": "^4.0.0",
+        "eventemitter2": "^6.0.0",
         "lodash": "^4.17.15",
         "pbkdf2": "^3.0.17",
         "winston": "^3.2.1"
       },
       "dependencies": {
-        "@dashevo/dapi-client": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.7.0.tgz",
-          "integrity": "sha512-48G+12JpyGrLm6/LpkJ0zVJSUamPMDEXQT6121LaFOxQ1nD9DHfccomdgUCZG/dQCyI9RI79ULW+Wij3ZRuyPQ==",
+        "@dashevo/dashcore-lib": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.18.0.tgz",
+          "integrity": "sha512-oh+lEdZYbjwY8PVoQBPPXtmtTH0RiT8jAqYXgIEL0krGP+NhwaLhuKzcFLDymfYCloWewMxC8sLpYBoFz98xRw==",
           "requires": {
-            "@babel/polyfill": "^7.2.5",
-            "@dashevo/dapi-grpc": "^0.11.0",
-            "@dashevo/dash-spv": "^1.1.5",
-            "@dashevo/dashcore-lib": "^0.17.1",
-            "axios": "^0.19.0",
-            "lodash": "^4.17.11",
-            "lowdb": "^1.0.0"
-          },
-          "dependencies": {
-            "@dashevo/dashcore-lib": {
-              "version": "0.17.12",
-              "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-              "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-              "requires": {
-                "@dashevo/x11-hash-js": "^1.0.2",
-                "bloom-filter": "^0.2.0",
-                "bn.js": "=4.11.8",
-                "bs58": "=4.0.1",
-                "elliptic": "=6.4.1",
-                "inherits": "=2.0.1",
-                "lodash": "^4.17.15",
-                "unorm": "^1.4.1"
-              }
-            }
-          }
-        },
-        "@dashevo/dapi-grpc": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.11.0.tgz",
-          "integrity": "sha512-z9DymGOp/pUkhS4ILlFHdz1e2jdukMPFltHzaPqZ+egJ0M9Q6GhUARqvNJCZ46TcuHhtkUzxbLQu4UHZ5Zojlg==",
-          "requires": {
-            "@dashevo/grpc-common": "^0.2.0",
-            "google-protobuf": "^3.8.0",
-            "grpc": "^1.24.0",
-            "grpc-web": "^1.0.6",
-            "protobufjs": "^6.8.8"
+            "@dashevo/x11-hash-js": "^1.0.2",
+            "@types/node": "^12.12.12",
+            "bloom-filter": "^0.2.0",
+            "bn.js": "=4.11.8",
+            "bs58": "=4.0.1",
+            "elliptic": "=6.4.1",
+            "inherits": "=2.0.1",
+            "lodash": "^4.17.15",
+            "unorm": "^1.4.1"
           }
         }
       }
@@ -652,7 +654,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -765,15 +766,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1238,6 +1230,11 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -1466,11 +1463,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-    },
-    "commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -1717,9 +1709,9 @@
       }
     },
     "crypto-js": {
-      "version": "3.1.9-1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -1832,11 +1824,6 @@
           }
         }
       }
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -2045,9 +2032,9 @@
       }
     },
     "env-variable": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
     },
     "errno": {
       "version": "0.1.7",
@@ -2112,8 +2099,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -2135,6 +2121,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
+    },
+    "eventemitter2": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.0.0.tgz",
+      "integrity": "sha512-ZuNWHD7S7IoikyEmx35vPU8H1W0L+oi644+4mSTg7nwXvBQpIwQL7DPjYUF0VMB0jPkNMo3MqD07E7MYrkFmjQ=="
     },
     "events": {
       "version": "3.0.0",
@@ -3704,7 +3695,8 @@
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.5",
@@ -3920,7 +3912,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3932,18 +3923,20 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.3.tgz",
+      "integrity": "sha512-/Lmyl0PW27dOmCO03PI339+1gs4Z2PlqIyUgzIOtoRp08zkkMCB30TRbdppbPO7WWzZX0uT98HqkDiZSujkmbA==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^6.0.0"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
     },
     "json5": {
       "version": "1.0.1",
@@ -4043,21 +4036,6 @@
         "xtend": "~4.0.0"
       }
     },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "requires": {
-        "immediate": "~3.0.5"
-      },
-      "dependencies": {
-        "immediate": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-        }
-      }
-    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -4073,14 +4051,6 @@
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
         "json5": "^1.0.1"
-      }
-    },
-    "localforage": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
-      "requires": {
-        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -4958,6 +4928,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "ono": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
+      "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
     },
     "opener": {
       "version": "1.5.1",
@@ -5958,8 +5933,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssri": {
       "version": "6.0.1",
@@ -8149,9 +8123,9 @@
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/dashevo/DashJS#readme",
   "dependencies": {
-    "@dashevo/dapi-client": "~0.8.0-dev.14",
-    "@dashevo/dashcore-lib": "~0.18.0",
-    "@dashevo/dpp": "0.10.0-dev.14",
-    "@dashevo/wallet-lib": "5.0.3",
+    "@dashevo/dapi-client": "~0.9.0-dev.6",
+    "@dashevo/dashcore-lib": "^0.18.0",
+    "@dashevo/dpp": "^0.11.0-dev.4",
+    "@dashevo/wallet-lib": "^6.0.0",
     "bs58": "^4.0.1"
   },
   "devDependencies": {

--- a/src/DashJS/SDK/Platform/Platform.ts
+++ b/src/DashJS/SDK/Platform/Platform.ts
@@ -8,6 +8,8 @@ import broadcastDocument from "./methods/documents/broadcast";
 import createDocument from "./methods/documents/create";
 import getDocument from "./methods/documents/get";
 
+import broadcastRecords from "./methods/broadcastRecords";
+
 import broadcastContract from "./methods/contracts/broadcast";
 import createContract from "./methods/contracts/create";
 import getContract from "./methods/contracts/get";
@@ -24,7 +26,7 @@ import {Account} from "@dashevo/wallet-lib";
 
 /**
  * Interface for PlatformOpts
- * 
+ *
  * @remarks
  * required parameters include { client, apps }
  * optional parameters include { ..., account?, network? }
@@ -58,7 +60,7 @@ interface Credentials {
 
 /**
  * Class for Dash Platform
- * 
+ *
  * @param documents - documents
  * @param identities - identites
  * @param names - names
@@ -66,7 +68,7 @@ interface Credentials {
  */
 export class Platform {
     dpp: DashPlatformProtocol;
-    
+
     public documents: Records;
     /**
      * @param {Function} get - get identities from the platform
@@ -91,7 +93,7 @@ export class Platform {
 
     /**
      * Construct some instance of Platform
-     * 
+     *
      * @param {platformOpts} - options for Platform
      */
     constructor(platformOpts: PlatformOpts) {
@@ -113,6 +115,7 @@ export class Platform {
             register: registerIdentity.bind(this),
             get: getIdentity.bind(this),
         };
+
         this.dpp = new DashPlatformProtocol(platformOpts);
         this.client = platformOpts.client;
         this.apps = platformOpts.apps;

--- a/src/DashJS/SDK/Platform/Platform.ts
+++ b/src/DashJS/SDK/Platform/Platform.ts
@@ -22,6 +22,13 @@ import registerName from "./methods/names/register";
 // @ts-ignore
 import {Account} from "@dashevo/wallet-lib";
 
+/**
+ * Interface for PlatformOpts
+ * 
+ * @remarks
+ * required parameters include { client, apps }
+ * optional parameters include { ..., account?, network? }
+ */
 export interface PlatformOpts {
     client: DAPIClient,
     apps: SDKApps
@@ -29,32 +36,64 @@ export interface PlatformOpts {
     network?: string
 }
 
+/**
+ * @param {Function} broadcast - broadcast records onto the platform
+ * @param {Function} create - create records which can be broadcasted
+ * @param {Function} get - get records from the platform
+ */
+interface Records {
+    broadcast:Function,
+    create:Function,
+    get:Function,
+};
 
+/**
+ * @param {Function} broadcast - broadcast credentials onto the platform
+ * @param {Function} get - get credentials from the platform
+ */
+interface Credentials {
+    get:Function,
+    register:Function,
+}
+
+/**
+ * Class for Dash Platform
+ * 
+ * @param documents - documents
+ * @param identities - identites
+ * @param names - names
+ * @param contracts - contracts
+ */
 export class Platform {
     dpp: DashPlatformProtocol;
-    public documents: {
-        broadcast:Function,
-        create:Function,
-        get:Function,
-    };
-    public identities: {
-        get:Function,
-        register:Function,
-    };
-    public names: {
-        get:Function,
-        register:Function,
-    };
-    public contracts: {
-        broadcast:Function,
-        create:Function,
-        get:Function
-    };
+    
+    public documents: Records;
+    /**
+     * @param {Function} get - get identities from the platform
+     * @param {Function} register - register identities on the platform
+     */
+    public identities: Credentials;
+    /**
+     * @param {Function} get - get names from the platform
+     * @param {Function} register - register names on the platform
+     */
+    public names: Credentials;
+    /**
+     * @param {Function} get - get contracts from the platform
+     * @param {Function} create - create contracts which can be broadcasted
+     * @param {Function} register - register contracts on the platform
+     */
+    public contracts: Records;
     client: DAPIClient;
     apps: SDKApps;
     account?: Account;
     network?: string;
 
+    /**
+     * Construct some instance of Platform
+     * 
+     * @param {platformOpts} - options for Platform
+     */
     constructor(platformOpts: PlatformOpts) {
         this.documents = {
             broadcast: broadcastDocument.bind(this),

--- a/src/DashJS/SDK/Platform/methods/broadcastRecords.ts
+++ b/src/DashJS/SDK/Platform/methods/broadcastRecords.ts
@@ -1,0 +1,25 @@
+import {Platform} from "../../Platform";
+import StateTransitionBuilder from "../../StateTransitionBuilder/StateTransitionBuilder";
+
+/**
+ * Register the set of records provided by creating and broadcasting a stateTransition.
+ *
+ * @param {Platform} this - bound instance class
+ * @param records - records to register onto platform
+ * @param identity - identity
+ */
+export async function broadcastRecords(this: Platform, records: [any], identity: any): Promise<any> {
+    const {account, client, dpp} = this;
+
+    const builder = new StateTransitionBuilder({
+        dpp,
+        client
+    });
+    builder.addRecord(records);
+
+    // @ts-ignore
+    const identityPrivateKey = account.getIdentityHDKey(0, 'user').privateKey;
+    await builder.register(identity, identityPrivateKey);
+}
+
+export default broadcastRecords;

--- a/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
@@ -1,6 +1,3 @@
-import {Platform} from "../../Platform";
-import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../StateTransitionBuilder/StateTransitionBuilder";
-
 /**
  * Broadcast contract onto the platform
  *
@@ -8,14 +5,5 @@ import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../Stat
  * @param contract - contract
  * @param identity - identity
  */
-export async function broadcast(this: Platform, contract: any, identity: any): Promise<any> {
-    const {account, client, dpp} = this;
-
-    const builder = new StateTransitionBuilder({type: StateTransitionBuilderTypes.CONTRACT, dpp, client});
-    builder.addRecord(contract);
-    // @ts-ignore
-    const identityPrivateKey = account.getIdentityHDKey(0, 'user').privateKey;
-    await builder.register(identity, identityPrivateKey);
-}
-
+import broadcast from "../broadcastRecords";
 export default broadcast;

--- a/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
@@ -1,5 +1,12 @@
 import {Platform} from "../../Platform";
 
+/**
+ * Broadcast contract onto the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param contract - contract
+ * @param identity - identity
+ */
 export async function broadcast(this: Platform, contract: any, identity: any): Promise<any> {
     const {account, client, dpp} = this;
 

--- a/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
@@ -1,8 +1,9 @@
 import {Platform} from "../../Platform";
+import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../StateTransitionBuilder/StateTransitionBuilder";
 
 /**
  * Broadcast contract onto the platform
- * 
+ *
  * @param {Platform} this - bound instance class
  * @param contract - contract
  * @param identity - identity
@@ -10,18 +11,11 @@ import {Platform} from "../../Platform";
 export async function broadcast(this: Platform, contract: any, identity: any): Promise<any> {
     const {account, client, dpp} = this;
 
+    const builder = new StateTransitionBuilder({type: StateTransitionBuilderTypes.CONTRACT, dpp, client});
+    builder.addRecord(contract);
     // @ts-ignore
-    const identityHDPrivateKey = account.getIdentityHDKey(0, 'user');
-
-    // @ts-ignore
-    const identityPrivateKey = identityHDPrivateKey.privateKey;
-
-    const stateTransition = dpp.dataContract.createStateTransition([contract]);
-    stateTransition.sign(identity.getPublicKeyById(1), identityPrivateKey);
-
-    // @ts-ignore
-    await client.applyStateTransition(stateTransition);
-
+    const identityPrivateKey = account.getIdentityHDKey(0, 'user').privateKey;
+    await builder.register(identity, identityPrivateKey);
 }
 
 export default broadcast;

--- a/src/DashJS/SDK/Platform/methods/contracts/create.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/create.ts
@@ -1,8 +1,8 @@
 import {Platform} from "../../Platform";
 
 /**
- * Create contracts on the platform
- * 
+ * Create and prepare contracts for the platform
+ *
  * @param {Platform} this - bound instance class
  * @param documentDefinitions - document definitions
  * @param identity - identity

--- a/src/DashJS/SDK/Platform/methods/contracts/create.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/create.ts
@@ -1,5 +1,13 @@
 import {Platform} from "../../Platform";
 
+/**
+ * Create contracts on the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param documentDefinitions - document definitions
+ * @param identity - identity
+ * @returns created contracts
+ */
 export function create(this: Platform, documentDefinitions: any, identity: any): Promise<any> {
     return this.dpp.dataContract.create(identity.getId(), documentDefinitions);;
 }

--- a/src/DashJS/SDK/Platform/methods/contracts/get.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/get.ts
@@ -2,6 +2,13 @@ import {Platform} from "../../Platform";
 
 declare type ContractIdentifier = string;
 
+/**
+ * Get contracts from the platform
+ * 
+ * @param {Platform} this - bound instance class 
+ * @param {ContractIdentifier} identifier - identifier
+ * @returns contracts
+ */
 export async function get(this: Platform, identifier: ContractIdentifier): Promise<any> {
     let localContract;
 

--- a/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
@@ -1,8 +1,9 @@
 import {Platform} from "../../Platform";
+import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../StateTransitionBuilder/StateTransitionBuilder";
 
 /**
  * Broadcast document onto the platform
- * 
+ *
  * @param {Platform} this - bound instance class
  * @param document - document
  * @param identity - identity
@@ -10,18 +11,11 @@ import {Platform} from "../../Platform";
 export async function broadcast(this: Platform, document: any, identity: any): Promise<any> {
     const {account, client, dpp} = this;
 
+    const builder = new StateTransitionBuilder({type: StateTransitionBuilderTypes.DOCUMENT, dpp, client});
+    builder.addRecord(document);
     // @ts-ignore
-    const identityHDPrivateKey = account.getIdentityHDKey(0, 'user');
-
-    // @ts-ignore
-    const identityPrivateKey = identityHDPrivateKey.privateKey;
-
-    const stateTransition = dpp.document.createStateTransition([document]);
-    stateTransition.sign(identity.getPublicKeyById(1), identityPrivateKey);
-
-    // @ts-ignore
-    await client.applyStateTransition(stateTransition);
-
+    const identityPrivateKey = account.getIdentityHDKey(0, 'user').privateKey;
+    await builder.register(identity, identityPrivateKey);
 }
 
 export default broadcast;

--- a/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
@@ -1,8 +1,14 @@
 import {Platform} from "../../Platform";
 
-
+/**
+ * Broadcast document onto the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param document - document
+ * @param identity - identity
+ */
 export async function broadcast(this: Platform, document: any, identity: any): Promise<any> {
-    const { account, client, dpp } = this;
+    const {account, client, dpp} = this;
 
     // @ts-ignore
     const identityHDPrivateKey = account.getIdentityHDKey(0, 'user');
@@ -15,6 +21,7 @@ export async function broadcast(this: Platform, document: any, identity: any): P
 
     // @ts-ignore
     await client.applyStateTransition(stateTransition);
+
 }
 
 export default broadcast;

--- a/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/broadcast.ts
@@ -1,6 +1,3 @@
-import {Platform} from "../../Platform";
-import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../StateTransitionBuilder/StateTransitionBuilder";
-
 /**
  * Broadcast document onto the platform
  *
@@ -8,14 +5,5 @@ import StateTransitionBuilder, {StateTransitionBuilderTypes} from "../../../Stat
  * @param document - document
  * @param identity - identity
  */
-export async function broadcast(this: Platform, document: any, identity: any): Promise<any> {
-    const {account, client, dpp} = this;
-
-    const builder = new StateTransitionBuilder({type: StateTransitionBuilderTypes.DOCUMENT, dpp, client});
-    builder.addRecord(document);
-    // @ts-ignore
-    const identityPrivateKey = account.getIdentityHDKey(0, 'user').privateKey;
-    await builder.register(identity, identityPrivateKey);
-}
-
+import broadcast from "../broadcastRecords";
 export default broadcast;

--- a/src/DashJS/SDK/Platform/methods/documents/create.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/create.ts
@@ -4,6 +4,15 @@ declare interface createOpts {
     [name:string]: any;
 }
 
+/**
+ * Create documents on the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param {string} typeLocator - type locator
+ * @param identity - identity
+ * @param {createOpts} opts - options 
+ * @param {[string]:any} [opts.name] - documents names
+ */
 export async function create(this: Platform, typeLocator: string, identity: any, opts: createOpts): Promise<any> {
     const { dpp } = this;
 

--- a/src/DashJS/SDK/Platform/methods/documents/create.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/create.ts
@@ -5,12 +5,12 @@ declare interface createOpts {
 }
 
 /**
- * Create documents on the platform
- * 
+ * Create and prepare documents for the platform
+ *
  * @param {Platform} this - bound instance class
  * @param {string} typeLocator - type locator
  * @param identity - identity
- * @param {createOpts} opts - options 
+ * @param {createOpts} opts - options
  * @param {[string]:any} [opts.name] - documents names
  */
 export async function create(this: Platform, typeLocator: string, identity: any, opts: createOpts): Promise<any> {

--- a/src/DashJS/SDK/Platform/methods/documents/get.ts
+++ b/src/DashJS/SDK/Platform/methods/documents/get.ts
@@ -1,5 +1,11 @@
 import {Platform} from "../../Platform";
-
+/**
+ * @param {any} [where] - where
+ * @param {any} [orderBy] - order by
+ * @param {number} [limit] - limit
+ * @param {number} [startAt] - start value (included)
+ * @param {number} [startAfter] - start value (not included)
+ */
 declare interface fetchOpts {
     where: any;
     orderBy: any;
@@ -8,6 +14,14 @@ declare interface fetchOpts {
     startAfter: number;
 }
 
+/**
+ * Get documents from the platform
+ * 
+ * @param {Platform} this bound instance class
+ * @param {string} typeLocator type locator
+ * @param {fetchOpts} opts - MongoDB style query
+ * @returns documents
+ */
 export async function get(this: Platform, typeLocator: string, opts: fetchOpts): Promise<any> {
     const appNames = Object.keys(this.apps);
 

--- a/src/DashJS/SDK/Platform/methods/identities/get.ts
+++ b/src/DashJS/SDK/Platform/methods/identities/get.ts
@@ -1,5 +1,12 @@
 import {Platform} from "../../Platform";
 
+/**
+ * Get identies from the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param {string} id - id
+ * @returns identites
+ */
 export async function get(this: Platform, id: string): Promise<any> {
     // @ts-ignore
     const identityBuffer = await this.client.getIdentity(id);

--- a/src/DashJS/SDK/Platform/methods/identities/register.ts
+++ b/src/DashJS/SDK/Platform/methods/identities/register.ts
@@ -9,6 +9,13 @@ const IdentityCreateTransition = require('@dashevo/dpp/lib/identity/stateTransit
 
 import {Platform} from "../../Platform";
 
+/**
+ * Register identities to the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param {string} identityType - identity type (non case sensitive), default value is set to 'USER'
+ * @returns registered identities
+ */
 export async function register(this: Platform, identityType: string = 'USER'): Promise<any> {
     const { account, client } = this;
 

--- a/src/DashJS/SDK/Platform/methods/names/get.ts
+++ b/src/DashJS/SDK/Platform/methods/names/get.ts
@@ -1,5 +1,11 @@
 import {Platform} from "../../Platform";
 
+/**
+ * Get names from the platform
+ * @param {Platform} this - bound instance class
+ * @param {string} id - id
+ * @returns names
+ */
 export async function get(this: Platform, id: string): Promise<any> {
     const queryOpts = {
         where: [

--- a/src/DashJS/SDK/Platform/methods/names/register.ts
+++ b/src/DashJS/SDK/Platform/methods/names/register.ts
@@ -3,6 +3,18 @@ const entropy = require('@dashevo/dpp/lib/util/entropy');
 const { hash } = require('@dashevo/dpp/lib/util/multihashDoubleSHA256');
 const bs58 = require('bs58');
 
+/**
+ * Register names to the platform
+ * 
+ * @param {Platform} this - bound instance class
+ * @param {string} name - name
+ * @param identity - identity
+ * @param {any} [identity.id] - identity ID
+ * @param {number} [identity.type] - identity type
+ * @param {[any]} [identity.publicKeys] - identity public keys
+ * @param {function(number):any} - get public key by ID
+ * @returns registered names
+ */
 export async function register(this: Platform,
                                name: string,
                                identity: {

--- a/src/DashJS/SDK/SDK.ts
+++ b/src/DashJS/SDK/SDK.ts
@@ -10,10 +10,9 @@ import isReady from "./methods/isReady";
  * default seed passed to SDK options
  */
 const defaultSeeds = [
-    '34.214.221.50',
-    '54.213.18.11',
-    '34.211.149.102',
-    '52.38.244.67',
+    '52.26.165.185',
+    '54.202.56.123',
+    '54.245.133.124',
 ].map(ip => ({service: `${ip}:3000`}));
 
 

--- a/src/DashJS/SDK/SDK.ts
+++ b/src/DashJS/SDK/SDK.ts
@@ -10,9 +10,10 @@ import isReady from "./methods/isReady";
  * default seed passed to SDK options
  */
 const defaultSeeds = [
-    '52.26.165.185',
-    '54.202.56.123',
-    '54.245.133.124',
+    '34.214.221.50',
+    '54.213.18.11',
+    '34.211.149.102',
+    '52.38.244.67',
 ].map(ip => ({service: `${ip}:3000`}));
 
 
@@ -20,7 +21,7 @@ export type DPASchema = object
 
 /**
  * Interface SDK Options
- * 
+ *
  * @param {[string]?} [seeds] - wallet seeds
  * @param {Network? | string?} [network] - evonet network
  * @param {Mnemonic? | string? | null?} [mnemonic] - mnemonic passphrase
@@ -75,8 +76,8 @@ export class SDK {
     public isReady: Function;
 
     /**
-     * Construct some instance of DAPI SDK 
-     * 
+     * Construct some instance of DAPI SDK
+     *
      * @param {opts} SDKOpts - options for DAPI SDK
      */
     constructor(opts: SDKOpts = {}) {
@@ -85,7 +86,7 @@ export class SDK {
         this.network = (opts.network !== undefined) ? opts.network.toString() : 'testnet';
         this.apps = Object.assign({
             dpns: {
-                contractId: '2KfMcMxktKimJxAZUeZwYkFUsEcAZhDKEpQs8GMnpUse'
+                contractId: 'BSwrqgq7idvxgBWSHWsmxyoi1XHDXU1URoDVaRXFozhp'
             }
         }, opts.apps);
 
@@ -153,7 +154,7 @@ export class SDK {
     }
 
     /**
-     * disconnect wallet from Dapi 
+     * disconnect wallet from Dapi
      */
     async disconnect() {
         if (this.wallet) {
@@ -163,10 +164,10 @@ export class SDK {
 
     /**
      * fetch some instance of DAPI client
-     * 
+     *
      * @remarks
      * This function throws an error message when there is no client DAPI instance
-     * 
+     *
      * @returns DAPI client instance
      */
     getDAPIInstance() {
@@ -178,10 +179,10 @@ export class SDK {
 
     /**
      * fetch list of applications
-     * 
+     *
      * @remarks
      * check if returned value can be null on devnet
-     * 
+     *
      * @returns applications list
      */
     getApps(): SDKApps {

--- a/src/DashJS/SDK/SDK.ts
+++ b/src/DashJS/SDK/SDK.ts
@@ -6,6 +6,9 @@ import DAPIClient from "@dashevo/dapi-client"
 import {Network, Mnemonic} from "@dashevo/dashcore-lib";
 import isReady from "./methods/isReady";
 
+/**
+ * default seed passed to SDK options
+ */
 const defaultSeeds = [
     '52.26.165.185',
     '54.202.56.123',
@@ -15,6 +18,15 @@ const defaultSeeds = [
 
 export type DPASchema = object
 
+/**
+ * Interface SDK Options
+ * 
+ * @param {[string]?} [seeds] - wallet seeds
+ * @param {Network? | string?} [network] - evonet network
+ * @param {Mnemonic? | string? | null?} [mnemonic] - mnemonic passphrase
+ * @param {SDKApps?} [apps] - applications
+ * @param {number?} [accountIndex] - account index number
+ */
 export interface SDKOpts {
     seeds?: [string];
     network?: Network | string,
@@ -23,14 +35,24 @@ export interface SDKOpts {
     accountIndex?: number,
 }
 
+/**
+ * Defined Type for SDK Client
+ */
 export type SDKClient = object | DAPIClient;
 
+/**
+ * Interface for SDKClients
+ * @typeparam SDKClient object or DAPIClient
+ */
 export interface SDKClients {
     [name: string]: SDKClient,
 
     dapi: DAPIClient
 }
 
+/**
+ * Interface for SDKApps
+ */
 export interface SDKApps {
     [name: string]: {
         contractId: string,
@@ -38,6 +60,9 @@ export interface SDKApps {
     }
 }
 
+/**
+ * class for SDK
+ */
 export class SDK {
     public network: string = 'testnet';
     public wallet: Wallet | undefined;
@@ -49,6 +74,11 @@ export class SDK {
     public state: { isReady: boolean, isAccountReady: boolean };
     public isReady: Function;
 
+    /**
+     * Construct some instance of DAPI SDK 
+     * 
+     * @param {opts} SDKOpts - options for DAPI SDK
+     */
     constructor(opts: SDKOpts = {}) {
         this.isReady = isReady.bind(this);
 
@@ -122,14 +152,23 @@ export class SDK {
 
     }
 
-
+    /**
+     * disconnect wallet from Dapi 
+     */
     async disconnect() {
         if (this.wallet) {
             await this.wallet.disconnect();
         }
     }
 
-
+    /**
+     * fetch some instance of DAPI client
+     * 
+     * @remarks
+     * This function throws an error message when there is no client DAPI instance
+     * 
+     * @returns DAPI client instance
+     */
     getDAPIInstance() {
         if (this.clients['dapi'] == undefined) {
             throw new Error(`There is no client DAPI`);
@@ -137,7 +176,14 @@ export class SDK {
         return this.clients['dapi'];
     }
 
-
+    /**
+     * fetch list of applications
+     * 
+     * @remarks
+     * check if returned value can be null on devnet
+     * 
+     * @returns applications list
+     */
     getApps(): SDKApps {
         return this.apps;
     }

--- a/src/DashJS/SDK/StateTransitionBuilder/StateTransitionBuilder.ts
+++ b/src/DashJS/SDK/StateTransitionBuilder/StateTransitionBuilder.ts
@@ -1,0 +1,107 @@
+// @ts-ignore
+import DAPIClient from "@dashevo/dapi-client";
+
+import {PrivateKey} from "@dashevo/dashcore-lib";
+// @ts-ignore
+import Document from "@dashevo/dpp/lib/document/Document";
+// @ts-ignore
+import DataContract from "@dashevo/dpp/lib/dataContract/DataContract";
+// @ts-ignore
+import Identity from "@dashevo/dpp/lib/identity/Identity";
+// @ts-ignore
+import DashPlatformProtocol from "@dashevo/dpp";
+
+export const enum StateTransitionBuilderTypes {
+    CONTRACT = 'dataContract',
+    DOCUMENT = 'document',
+    IDENTITY = 'identity',
+}
+
+export type Record = Document | DataContract | Identity;
+
+export interface StateTransitionBuilderOpts {
+    type: StateTransitionBuilderTypes,
+    dpp: DashPlatformProtocol,
+    client?: DAPIClient
+};
+
+const getTypeOfRecord = (record: Record) => {
+    switch (typeof record) {
+        case Document.prototype.name:
+            return StateTransitionBuilderTypes.DOCUMENT;
+        case DataContract.prototype.name:
+            return StateTransitionBuilderTypes.CONTRACT;
+        case Identity.prototype.name:
+            return StateTransitionBuilderTypes.IDENTITY;
+        default:
+            throw new Error('Invalid record type');
+    }
+}
+
+/**
+ * Builder for ST. Allows to manage and broadcast a set of record
+ *
+ * @param {StateTransitionBuilderTypes} type - a valid st builder type
+ * @param dpp - DashPlatformProtocol instance
+ * @param client - DAPIClient instance
+ */
+export class StateTransitionBuilder {
+    public records: Record[];
+    public type: StateTransitionBuilderTypes;
+
+    private dpp: DashPlatformProtocol | undefined;
+    private client: DAPIClient | undefined;
+
+    constructor(opts: StateTransitionBuilderOpts) {
+        this.type = opts.type || StateTransitionBuilderTypes.DOCUMENT;
+
+        if (opts.client) this.client = opts.client;
+        if (opts.dpp === undefined) {
+            throw new Error('Records requires a DPP instance for stateTransition creation');
+        }
+        this.dpp = opts.dpp;
+        this.records = [];
+    }
+
+    /**
+     * Allow to add a new record
+     * @param record - a valid record
+     */
+    addRecord(record: Record) {
+        let recordType = getTypeOfRecord(record);
+        if (recordType !== this.type) {
+            throw new Error(`Records cannot add to records of type ${this.type}: record type ${recordType}`);
+        }
+        this.records.push(record);
+    }
+
+    /**
+     * Register the records to the platform by broadcasting a state transition.
+     *
+     * @param {Identity} identity - identity with which broadcast theses records
+     * @param {PrivateKey} identityPrivateKey - private key associate to the identity for ST signing.
+     */
+    async register(identity: Identity, identityPrivateKey: PrivateKey) {
+        const dapiClient = this.client;
+        if (!dapiClient) {
+            throw new Error('Requires a DAPIClient instance for stateTransition creation');
+        }
+        let stateTransition = this.toStateTransition();
+
+        stateTransition.sign(identity.getPublicKeyById(1), identityPrivateKey);
+
+        // @ts-ignore
+        await dapiClient.applyStateTransition(stateTransition);
+
+    }
+
+    /**
+     * Returns a StateTransition containing the records
+     * @return {DataContractStateTransition|DocumentsStateTransition|IdentityCreateTransition}
+     */
+    toStateTransition() {
+        return this.dpp[this.type].createStateTransition(this.records)
+    }
+}
+
+export default StateTransitionBuilder;

--- a/src/DashJS/SDK/StateTransitionBuilder/getTypeOfRecord.ts
+++ b/src/DashJS/SDK/StateTransitionBuilder/getTypeOfRecord.ts
@@ -1,0 +1,21 @@
+// @ts-ignore
+import Document from "@dashevo/dpp/lib/document/Document";
+// @ts-ignore
+import DataContract from "@dashevo/dpp/lib/dataContract/DataContract";
+// @ts-ignore
+import Identity from "@dashevo/dpp/lib/identity/Identity";
+import {Record, StateTransitionBuilderTypes} from "./StateTransitionBuilder";
+
+const getTypeOfRecord = (record: Record) => {
+    switch (typeof record) {
+        case Document.prototype.name:
+            return StateTransitionBuilderTypes.DOCUMENT;
+        case DataContract.prototype.name:
+            return StateTransitionBuilderTypes.CONTRACT;
+        case Identity.prototype.name:
+            return StateTransitionBuilderTypes.IDENTITY;
+        default:
+            throw new Error('Invalid record type');
+    }
+}
+export default getTypeOfRecord;

--- a/src/DashJS/SDK/methods/isReady.ts
+++ b/src/DashJS/SDK/methods/isReady.ts
@@ -1,3 +1,11 @@
+/**
+ * Report state in a fixed interval of time [100 ms]
+ * 
+ * @param this bound class instance
+ * 
+ * @remarks
+ * isReady calls isSelfReady to check report state
+ */
 const isSelfReady = async function(this: any){
     const self = this;
     return new Promise((res)=>{
@@ -10,6 +18,12 @@ const isSelfReady = async function(this: any){
     })
 }
 
+/**
+ * Check if this instance state is reported ready
+ * 
+ * @param this bound class instance
+ * @returns true only if this is ready
+ */
 async function isReady(this: any) {
     const {state, account} = this;
     if (state.isAccountReady && state.isReady) {

--- a/typings/dapi-client.d.ts
+++ b/typings/dapi-client.d.ts
@@ -1,7 +1,7 @@
 declare module "@dashevo/dapi-client";
 
 /**
- * @param options
+ * @param options - DAPI client options
  * @param {Array<Object>} [options.seeds] - seeds. If no seeds provided
  * default seed will be used.
  * @param {number} [options.port=3000] - default port for connection to the DAPI
@@ -9,7 +9,14 @@ declare module "@dashevo/dapi-client";
  * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
  * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
  */
+
+ /**
+ * Class for DAPI Client 
+ */
 declare class DAPIClient {
+    /**
+     * Construct an instance of DAPI client
+     */
     constructor(options: {
         seeds?: object[];
         port?: number;


### PR DESCRIPTION
### Issue being fixed or implemented  

This PR is a direct follow-up on #30. 
Additionally to TypeScript typing documentation, Records get implemented as parent abstraction of dataContracts and documents (as initially proposed by @StEvUgnIn).

### What was done  

- docs: typing documentation (#30)
- refact: code cleanup (#30)
- refact: abstraction for ST creation/broadcasting (StateTransitionBuilder)

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
