### PR TITLE
fix(contracts): pass data contract without array

### DIFF
--- a/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
+++ b/src/DashJS/SDK/Platform/methods/contracts/broadcast.ts
@@ -9,7 +9,7 @@ export async function broadcast(this: Platform, contract: any, identity: any): P
     // @ts-ignore
     const identityPrivateKey = identityHDPrivateKey.privateKey;
 
-    const stateTransition = dpp.dataContract.createStateTransition([contract]);
+    const stateTransition = dpp.dataContract.createStateTransition(contract);
     stateTransition.sign(identity.getPublicKeyById(1), identityPrivateKey);
 
     // @ts-ignore


### PR DESCRIPTION
### Issue being fixed or implemented  
Fixes the ```TypeError: this.getDataContract(...).toJSON is not a function``` error encountered when trying to sign a data contract state transition.

### What was done
Remove the argument to dataContract.create() from array

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
