### PR TITLE
fix: update default seed ips for re-deployed evonet

### DIFF
--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -10,9 +10,9 @@ import isReady from "./methods/isReady";
  * default seed passed to SDK options
  */
 const defaultSeeds = [
-    '52.26.165.185',
-    '54.202.56.123',
-    '54.245.133.124',
+    '52.24.198.145',
+    '52.13.92.167',
+    '34.212.245.91',
 ].map(ip => ({service: `${ip}:3000`}));
 
 


### PR DESCRIPTION
### Issue being fixed or implemented  

Current seed IPs are out of date

### What was done  

Added seed IPs from redeployed evonet

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
