### PR TITLE
doc: update documentation wordings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to DashJS
+Contributing to Dash SDK
 ======================
 
 First off, thanks for taking the time to contribute!
@@ -55,7 +55,7 @@ Don't hesitate to use commit messages to explain more about the changes.
 
 #### Issues
 
-* Demonstrating the issue by creating a JSFiddle (you can inherit DashJS from unpkg) is definitely welcome. 
+* Demonstrating the issue by creating a JSFiddle (you can inherit Dash SDK from unpkg) is definitely welcome. 
 * **Use a clear and descriptive title** for the issue to identify the suggestion.
 * **Provide a comprehensive description of the suggested enhancement** in as much detail as possible. (a template is automatically generated for you when creating an issue / pr)
 * (If applicable) **Provide specific examples to demonstrate the steps**.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DashJS
+# Dash SDK
 
 [![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/dash)
 [![Build Status](https://img.shields.io/travis/com/dashevo/dashjs.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/dashjs)
@@ -6,7 +6,7 @@
 > Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)
 
 
-DashJS allows you to transact on L1 or fetch/register documents on L2 within a single library, including management and signing of your documents.
+Dash library allows you to transact on L1 or fetch/register documents on L2 within a single library, including management and signing of your documents.
 
 Find more in the : 
 - [Documentation](https://dashevo.github.io/DashJS/#/)
@@ -36,15 +36,15 @@ For browser usage, you can also directly rely on unpkg :
 ## Usage
 
 ```js
-const DashJS = require("dash");
+const Dash = require("dash");
 
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   network: "testnet",
   mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
 });
 
-sdk.isReady().then(async () => {
-  const {account, platform} = sdk;
+client.isReady().then(async () => {
+  const {account, platform} = client;
   console.log("Funding address", account.getUnusedAddress().address);
   console.log("Confirmed Balance", account.getConfirmedBalance());
   console.log(await platform.names.get('alice'));
@@ -54,13 +54,13 @@ sdk.isReady().then(async () => {
 
 ## Dependencies 
 
-DashJS works using multiple dependencies that might interest you :
+Dash SDK works using multiple dependencies that might interest you :
 - [Wallet-Lib](https://github.com/dashevo/wallet-lib) - Wallet management for handling, signing and broadcasting transactions (HD44).
 - [Dashcore-Lib](https://github.com/dashevo/dashcore-lib) - Providing the main primitives (Block, Transaction,...).
 - [DAPI-Client](https://github.com/dashevo/dapi-client) - Client library for accessing DAPI endpoints.
 - [DPP](https://github.com/dashevo/js-dpp) - Implementation (JS) of Dash Platform Protocol.
 
-Some features might be more extensive in those libs, as DashJS only wraps around them to provide a single interface that is easy to use (and thus has less features).
+Some features might be more extensive in those libs, as Dash SDK only wraps around them to provide a single interface that is easy to use (and thus has less features).
 
 ## Licence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## DashJS
+## Dash SDK
 
 [![Package Version](https://img.shields.io/github/package-json/v/dashevo/dashjs.svg?&style=flat-square)](https://www.npmjs.org/package/dash)
 [![Build Status](https://img.shields.io/travis/com/dashevo/dashjs.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/dashjs)
@@ -7,7 +7,7 @@
 
 ---
 
-DashJS is intended to provide, in a single entry-point all the different features, classes & utils you might need to interface with the Dash network.
+Dash SDK is intended to provide, in a single entry-point all the different features, classes & utils you might need to interface with the Dash network.
 
 ## Install
 
@@ -30,15 +30,15 @@ npm install dash
 ### Usage 
 
 ```
-const DashJS = require("dash");
+const Dash = require("dash");
 
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   network: "testnet",
   mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
 });
 
-sdk.isReady().then(async () => {
-  const {account, platform} = sdk;
+client.isReady().then(async () => {
+  const {account, platform} = client;
   console.log("Funding address", account.getUnusedAddress().address);
   console.log("Confirmed Balance", account.getConfirmedBalance());
   console.log(await platform.names.get('alice'));

--- a/docs/examples/fetch-an-identity-from-its-name.md
+++ b/docs/examples/fetch-an-identity-from-its-name.md
@@ -4,16 +4,16 @@ Assuming you have created an identity and attached a name to it (see how to [reg
 You will then be able to directly recover an identity from its names. See below: 
 
 ```js
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic: ''// Your app mnemonic, which holds the app identity
 });
 
 // This is the name previously registered in DPNS.
 const identityName = 'alice';
-sdk.isReady().then(getIdentity);
+client.isReady().then(getIdentity);
 
 async function getIdentity() {
-    const {identities, names} = sdk.platform;
+    const {identities, names} = client.platform;
     const identityId = (await names.get(identityName)).data.records.dashIdentity;
     const identity = await identities.get(identityId);
 }

--- a/docs/examples/generate-a-new-mnemonic.md
+++ b/docs/examples/generate-a-new-mnemonic.md
@@ -3,25 +3,25 @@
 In order to be able to keep your private keys private, we encourage to create your own mnemonic instead of using those from the examples (that might be empty).
 Below, you will be proposed two options allowing you to create a new mnemonic, depending on the level of customisation you need. 
 
-## DashJS.Client
+## Dash.Client
 
 By passing `null` to the mnemonic value, you can get Wallet-lib to generate a new mnemonic for you. 
 
 ```js
-const DashJS = require("dash");
-const sdk = new DashJS.Client({
+const Dash = require("dash");
+const client = new Dash.Client({
   network: "testnet",
   mnemonic: null,
 });
-const mnemonic = sdk.wallet.exportWallet();
+const mnemonic = client.wallet.exportWallet();
 console.log({mnemonic});
 ```
 
-## DashJS.Mnemonic 
+## Dash.Mnemonic 
 
 ```js
-const DashJS = require("dash");
-const {Mnemonic} = DashJS;
+const Dash = require("dash");
+const {Mnemonic} = Dash.Core;
 
 const mnemnonic = new Mnemonic.toString()
 ```
@@ -29,7 +29,7 @@ const mnemnonic = new Mnemonic.toString()
 ### Language selection 
 
 ```js
-const {Mnemonic} = DashJS;
+const {Mnemonic} = Dash.Core;
 const {CHINESE, ENGLISH, FRENCH, ITALIAN, JAPANESE, SPANISH} = Mnemonic.Words;
 console.log(new Mnemonic(Mnemonic.Words.FRENCH).toString())
 ```
@@ -39,7 +39,7 @@ console.log(new Mnemonic(Mnemonic.Words.FRENCH).toString())
 By default, the value for mnemonic is `128` (12 words), but you can generate a 24 words (or other) : 
 
 ```js
-const {Mnemonic} = DashJS;
+const {Mnemonic} = Dash.Core;
 console.log(new Mnemonic(256).toString())
 ```
 

--- a/docs/examples/pay-to-another-address.md
+++ b/docs/examples/pay-to-another-address.md
@@ -4,14 +4,16 @@ In order to pay, you need to have an [existing balance](/examples/receive-money-
 The below code will allow you to pay to a single address a specific amount of satoshis.
 
 ```js
-const DashJS = require("dash");
+const Dash = require("dash");
 const mnemonic = ''// your mnemonic here.
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic,
 });
-sdk.isReady().then(payToRecipient);
+
+client.isReady().then(payToRecipient);
+
 async function payToRecipient() {
-    const {account} = sdk;
+    const {account} = client;
     const transaction = account.createTransaction({
       recipient:"yNPbcFfabtNmmxKdGwhHomdYfVs6gikbPf",
       satoshis:10000

--- a/docs/examples/publishing-a-new-contract.md
+++ b/docs/examples/publishing-a-new-contract.md
@@ -11,22 +11,22 @@ and [attached to a name](https://dashplatform.readme.io/docs/tutorial-register-a
 
 ```js
 const schema = {};// You JSON schema defining the app.
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic: ''// Your app mnemonic, which holds the app identity
 });
 
 // This is the name previously registered in DPNS.
 const appName = 'MyApp';
-sdk.isReady().then(registerContract);
+client.isReady().then(registerContract);
 
 async function getIdentity(idName) {
-    const {identities, names} = sdk.platform;
+    const {identities, names} = client.platform;
     const identityId = (await names.get(idName)).data.records.dashIdentity;
     const identity = await identities.get(identityId);
     return identity
 }
 async function registerContract() {
-    const {platform} = sdk;
+    const {platform} = client;
     const identity = await getIdentity(appName);
     const contract = platform.contracts.create(schema, identity)
     const contractId = await platform.contracts.broadcast(contract, identity);
@@ -39,7 +39,7 @@ async function registerContract() {
 const schema = {};// You JSON schema defining the app.
 
 // This is the name previously registered in DPNS.
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic: "",// Your app mnemonic, which holds the app identity
   apps:{
     myapp:{
@@ -48,16 +48,16 @@ const sdk = new DashJS.Client({
   }
 });
 
-sdk.isReady().then(getDocuments);
+client.isReady().then(getDocuments);
 
 async function getDocuments() {
-    const {documents} = sdk.platform;
+    const {documents} = client.platform;
     const docs = await documents.fetch('myapp.myfield',{});
 }
 
 async function publishDocument(){
     const identity = await getIdentity(appName);
-    const {documents} = sdk.platform;
+    const {documents} = client.platform;
     const doc = await documents.create('myapp.myfield',identity, {myproperties:'my value'});
     await documents.broadcast(doc, identity)
 }

--- a/docs/examples/receive-money-and-check-balance.md
+++ b/docs/examples/receive-money-and-check-balance.md
@@ -1,31 +1,31 @@
 ## Receive money and display balance
 
-Initialize the SDK with your [generated mnemonic](/examples/generate-a-new-mnemonic) passed as an option.  
-By default, the SDK will work on Evonet, the only network having DAPI at the time of writing.
+Initialize the SDK Client with your [generated mnemonic](/examples/generate-a-new-mnemonic) passed as an option.  
+By default, the SDK Client will work on Evonet, the only network having DAPI at the time of writing.
 
 ```js
-const DashJS = require("dash");
+const Dash = require("dash");
 const mnemonic = ''// your mnemonic here.
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic,
 });
 ```
 
-Having set up your `sdk` instance, you be able to access the `account` and `wallet` instance generated from your mnemonic.
+Having set up your `client` instance, you be able to access the `account` and `wallet` instance generated from your mnemonic.
 
 You can read more on [change my account](/examples/change-my-account) as by default, you are on the first BIP44 account. 
 
 
 ## Generate a receiving address
 
-In DashJS, you have two different type of payment address, `external`, which are those used to receive you money from outside.   
+In a client, you have two different type of payment address, `external`, which are those used to receive you money from outside.   
 And `internal`, which is used internally for the chance of a payment you do to someone.  
 For your privacy, you might want to generate a new address at each payment.
 
 ```js
-   sdk.isReady().then(generateNewAddress);
+   client.isReady().then(generateNewAddress);
    async function generateNewAddress(){
-     const {address} = sdk.account.getUnusedAddress();
+     const {address} = client.account.getUnusedAddress();
      console.log(`New address: ${address}`)
    }
 ```
@@ -39,9 +39,9 @@ You probably most of the time want to rely of your confirmed balance when you ch
 Value is in satoshis (smallest unit).
 
 ```js
-   sdk.isReady().then(displayBalance);
+   client.isReady().then(displayBalance);
    async function displayBalance(){
-     const balance = sdk.account.getConfirmedBalance();
+     const balance = client.account.getConfirmedBalance();
      console.log(`Balance: ${balance}`)
    }
 ```
@@ -53,24 +53,24 @@ Or you might want to look-up for the `.getUnconfirmedBalance()` to have only the
 When a new unconfirmed transaction is received, you can receive notice of it, to perform a validation on the address and perform an action if needed.   
 
 ```js
-  sdk.account.events.on('FETCHED/UNCONFIRMED_TRANSACTION', (data)=>{
+  client.account.events.on('FETCHED/UNCONFIRMED_TRANSACTION', (data)=>{
     console.log('FETCHED/UNCONFIRMED_TRANSACTION');
     console.dir(data)
   });
 ```
 
-The return element can be used in coordination with a `new DashJS.Transaction()`
+The return element can be used in coordination with a `new Dash.Core.Transaction()`
 
 ## Get an address 
 
 In case you want to retrieve a specific address index : 
 
 ```js
-  const {address} = sdk.account.getAddress(2);
+  const {address} = client.account.getAddress(2);
 ```
 
 ## Get an internal address 
 
 ```js
-  const {address} = sdk.account.getAddress(2, 'internal');
+  const {address} = client.account.getAddress(2, 'internal');
 ```

--- a/docs/examples/sign-and-verify-messages.md
+++ b/docs/examples/sign-and-verify-messages.md
@@ -1,12 +1,12 @@
 ## Sign and verify messages
 
-DashJS exports the Message constructor `new DashJS.Message`.   
+Dash SDK exports the Message constructor inside the Core namespace `new Dash.Core.Message`.   
 
 You can refer to its documentation : https://github.com/dashevo/dashcore-message/blob/master/README.md
 
 ```js
-const pk = new DashJS.PrivateKey();
-const message = new DashJS.Message('hello, world');
+const pk = new Dash.Core.PrivateKey();
+const message = new Dash.Core.Message('hello, world');
 const signed = account.sign(message, pk);
 const verify = message.verify(pk.toAddress().toString(), signed.toString());
 ```

--- a/docs/examples/use-different-account.md
+++ b/docs/examples/use-different-account.md
@@ -1,26 +1,26 @@
 ## Using a different account 
 
-Because the SDK uses mostly a mnemonic to initialize itself, you can access to the other account defined by the [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
+Because the Client uses mostly a mnemonic to initialize itself, you can access to the other account defined by the [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
-As an helper for users and internal reference for `sdk.platform`. 
-By default, accessing to `sdk.account` is equivalent of `sdk.wallet.getAccount({index:0})`. 
+As an helper for users and internal reference for `client.platform`. 
+By default, accessing to `client.account` is equivalent of `client.wallet.getAccount({index:0})`. 
 Therefore usage might varies if you need to deal with platform or not. 
 
 
 ### Access to account without platform
 ```js  
    const accountIndex = 1;
-   const account = sdk.wallet.getAccount({index:accountIndex});
+   const account = client.wallet.getAccount({index:accountIndex});
    await account.isReady();
 ```
 
 ### Access to account with platform.
 
-You will actually need to replace `sdk.account` to get platform to correctly fetch the right account to use for signing and fetching UTXOs.
+You will actually need to replace `client.account` to get platform to correctly fetch the right account to use for signing and fetching UTXOs.
 
 ```js
 async function changeAccount(){
-   sdk.account = sdk.wallet.getAccount({index:1});
-   await sdk.account.isReady();
+   client.account = client.wallet.getAccount({index:1});
+   await client.account.isReady();
 }
 ```

--- a/docs/examples/use-local-evonet.md
+++ b/docs/examples/use-local-evonet.md
@@ -6,7 +6,7 @@ You will then need to pass the seed ip, and [register the DPNS contract](https:/
 
 ```js
 const seeds = [{service: '54.245.133.124'}];
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   seeds,
   apps: {
     dpns: {

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -10,7 +10,7 @@ At the core of Dash is the Payment Chain, in order to be able to transact on it,
 
 In order to access your UTXO, you will have to provide a valid mnemonic that will unlock the Wallet and automatically fetch the associated UTXOs.
 
-When a SDK instance is created, you can access your wallet via the `sdk.wallet` variable, with the [wallet-lib Wallet doc](https://dashevo.github.io/wallet-lib/#/usage/wallet)
+When a SDK instance is created, you can access your wallet via the `client.wallet` variable, with the [wallet-lib Wallet doc](https://dashevo.github.io/wallet-lib/#/usage/wallet)
 
 ## Account
 
@@ -18,14 +18,14 @@ Since the introduction of deterministic wallet ([BIP44](https://github.com/bitco
 
 It is the instance you will use most of the time for receiving or broadcasting payments. 
 
-You can access your account with `sdk.account` and see [how to use a different account](/examples/use-different-account) if you need to get a specific account index.
+You can access your account with `client.account` and see [how to use a different account](/examples/use-different-account) if you need to get a specific account index.
 
 ## App Schema and Contracts
 
 The Dash Platform Application Chain, provides to developers the ability to create application.   
 That application requires a set of rules and conditions describe in a portable document in the form of a JSON names : Application Schema.
 
-When registered, those app schema are called contracts and contains a contractId (namespace : `sdk.contracts`).  
-By default, DashJS supports DPNS (to attach a name to an identity), under the namespace `sdk.names` for evonet.  
+When registered, those app schema are called contracts and contains a contractId (namespace : `client.contracts`).  
+By default, this library supports DPNS (to attach a name to an identity), under the namespace `client.names` for evonet.  
 
 You can read more on [how to use DPNS on a local evonet](/examples/use-local-evonet.md) or [how to use multiple apps](/getting-started/multiple-apps.md)

--- a/docs/getting-started/dash-platform-applications.md
+++ b/docs/getting-started/dash-platform-applications.md
@@ -1,6 +1,6 @@
 ## DPNS
 
-DPNS is handled in DashJS under the namespace `sdk.names.*'`. [Read more here](/platform/names)
+DPNS is handled in Dash SDK's Client under the namespace `client.names.*'`. [Read more here](/platform/names)
 
 ## DashPay
 

--- a/docs/getting-started/multiple-apps.md
+++ b/docs/getting-started/multiple-apps.md
@@ -6,7 +6,7 @@ Assuming a contract DashPay and having a following `contractId: "77w8Xqn25HwJhjo
 You can then pass it as an options.
 
 ```js
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   apps: {
     dashpay: {
       contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3'
@@ -15,9 +15,9 @@ const sdk = new DashJS.Client({
 });
 ```
 
-This allow the methods `sdk.platform.documents.fetch` to provide you field selection. 
+This allow the methods `client.platform.documents.fetch` to provide you field selection. 
 Therefore, if the dashpay contract have a `profile` field that you wish to access, DashJS will allow you to do dot-syntax access :
 
 ```js
-const bobProfile = await sdk.platform.documents.fetch('dashpay.profile', {name:'bob'})
+const bobProfile = await client.platform.documents.fetch('dashpay.profile', {name:'bob'})
 ``` 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,10 +10,10 @@ npm install dash
 ```
 ## Initialization
 
-Let's create a DashJS SDK instance specifying both our mnemonic and the schema we wish to work with.
+Let's create a Dash SDK client instance specifying both our mnemonic and the schema we wish to work with.
 
 ```js
-const DashJS = require("../src");
+const Dash = require("../src");
 const opts = {
   network: 'testnet',
   apps: {
@@ -24,24 +24,24 @@ const opts = {
   },
   mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
 };
-const sdk = new DashJS.Client(opts);
-sdk.isReady().then(()=>{
-    const {account} = sdk;
+const client = new Dash.Client(opts);
+client.isReady().then(()=>{
+    const {account} = client;
     // Do something
  });
 ```
 
 Quick note :
-- If no mnemonic is provided, the subinstance `sdk.Wallet` will not be initiated (write function for platforms won't be usable).
+- If no mnemonic is provided, the subinstance `client.Wallet` will not be initiated (write function for platforms won't be usable).
 
-If you do not have any mnemonic, you can pass `null` to get one generated or omit that parameter to only use DashJS in `read-only`.  
+If you do not have any mnemonic, you can pass `null` to get one generated or omit that parameter to only use Dash.Client in `read-only`.  
 
 
 ## Make a payment
 
 ```js
-sdk.isReady().then(()=>{
-     const {account} = sdk;
+client.isReady().then(()=>{
+     const {account} = client;
 
     account
       .createTransaction({
@@ -56,8 +56,8 @@ sdk.isReady().then(()=>{
 At time of writing, you will need to have registered dashpay yourself, see on [publishing a new contract](/examples/publishing-a-new-contract.md).
 
 ```js
-sdk.isReady().then(async ()=>{
-    const {account} = sdk;
+client.isReady().then(async ()=>{
+    const {account} = client;
     const bobProfile = await account.platform.documents.fetch('dashpay.profile', {name:'bob'})
   });
 ```

--- a/docs/getting-started/with-typescript.md
+++ b/docs/getting-started/with-typescript.md
@@ -1,16 +1,16 @@
-In order to use DashJS with TypeScript.    
+In order to use Dash SDK with TypeScript.    
 
 Create a index.ts file  
 
 ```js
-import DashJS from 'dash';
-const sdkOpts = {
+import Dash from 'dash';
+const clientOpts = {
   network: 'testnet',
   mnemonic: null,// Will generate a new address, you should keep it.
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
-sdk.isReady().then(()=> console.log('isReady'));
+client.isReady().then(()=> console.log('isReady'));
 ```
 
 Have a following `tsconfig.json` file

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>DashJS - Dash client-side library for wallet payment/signing and application development.</title>
+    <title>Dash - Dash client-side library for wallet payment/signing and application development in Javascript environments.</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="keywords" content="dashjs, wallet-lib, dashcore-lib, dapi, dapi-client, dash platform, dash application, javascript, typescript">
+    <meta name="keywords" content="dash, dash sdk js, wallet-lib, dashcore-lib, dapi, dapi-client, dash platform, dash application, javascript, typescript">
     <meta name="description" content="Client-side library for dApp development.">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">

--- a/docs/platform/contracts/broadcast.md
+++ b/docs/platform/contracts/broadcast.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.contracts.broadcast(contract, identity)`    
+**Usage**: `client.platform.contracts.broadcast(contract, identity)`    
 **Description**: This method will sign and broadcast any valid contract. 
 
 Parameters: 

--- a/docs/platform/contracts/create.md
+++ b/docs/platform/contracts/create.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.contracts.create(contractDefinitions, identity)`    
+**Usage**: `client.platform.contracts.create(contractDefinitions, identity)`    
 **Description**: This method will return a Contract object initialized with the parameters defined and apply to the used identity. 
 
 Parameters: 
@@ -12,8 +12,8 @@ Parameters:
 ```js
   const identityId = '';// Your identity identifier.
   const json = {};// Your valid json contract definitions
-  const identity = await sdk.platform.identities.get(identityId);
-  const contract = sdk.platform.contracts.create(json, identity);
+  const identity = await client.platform.identities.get(identityId);
+  const contract = client.platform.contracts.create(json, identity);
 ```
 
 Returns : Contract.

--- a/docs/platform/contracts/get.md
+++ b/docs/platform/contracts/get.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.contracts.get(contractId)`    
+**Usage**: `client.platform.contracts.get(contractId)`    
 **Description**: This method will allow you to fetch back a contract from it's id. 
 
 Parameters: 
@@ -7,6 +7,6 @@ Parameters:
 |-------------------|---------|------------------	| -----------------------------------------------------------------	|
 | **identifier**    | string  | yes                 | Will fetch back the contract matching the identifier |
 
-**Example**: `await sdk.platform.contracts.get('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3')`
+**Example**: `await client.platform.contracts.get('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3')`
 
 Returns : Contract (or `null`).

--- a/docs/platform/documents/broadcast.md
+++ b/docs/platform/documents/broadcast.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.document.broadcast(document, identity)`    
+**Usage**: `client.platform.document.broadcast(document, identity)`    
 **Description**: This method will broadcast the document on the Application Chain
 
 Parameters: 

--- a/docs/platform/documents/create.md
+++ b/docs/platform/documents/create.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.documents.create(typeLocator, identity, documentOpts)`    
+**Usage**: `client.platform.documents.create(typeLocator, identity, documentOpts)`    
 **Description**: This method will return a Document object initialized with the parameters defined and apply to the used identity. 
 
 Parameters: 
@@ -13,5 +13,5 @@ Parameters:
 ```js
   // See https://github.com/dashevo/dpns-contract on how to get those value.
   const dpnsDocOpts =  {nameHash, label,normalizedLabel,normalizedParentDomainName,preorderSalt,records };
-  const document = sdk.platform.documents.create('dpns.domain', identity, dpnsDocOpts);
+  const document = client.platform.documents.create('dpns.domain', identity, dpnsDocOpts);
 ```

--- a/docs/platform/documents/get.md
+++ b/docs/platform/documents/get.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.documents.get(dotLocator, opts)`    
+**Usage**: `client.platform.documents.get(dotLocator, opts)`    
 **Description**: This method will allow you to fetch back a documents from params passed. 
 
 Parameters: 
@@ -27,5 +27,5 @@ Parameters:
              ['normalizedParentDomainName', '==', 'dash'],
          ],
      };
-  await sdk.platform.documents.get('dpns.domain', queryOpts);
+  await client.platform.documents.get('dpns.domain', queryOpts);
 ```

--- a/docs/platform/identities/get.md
+++ b/docs/platform/identities/get.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.identities.get(identityId)`    
+**Usage**: `client.platform.identities.get(identityId)`    
 **Description**: This method will allow you to fetch back an identity from it's id. 
 
 Parameters: 
@@ -7,6 +7,6 @@ Parameters:
 |-------------------|---------|------------------	| -----------------------------------------------------------------	|
 | **identifier**    | string  | yes                 | Will fetch back the identity matching the identifier              |
 
-**Example**: `await sdk.platform.identities.get('3GegupTgRfdN9JMS8R6QXF3B2VbZtiw63eyudh1oMJAk')`
+**Example**: `await client.platform.identities.get('3GegupTgRfdN9JMS8R6QXF3B2VbZtiw63eyudh1oMJAk')`
 
 Returns : Identity (or `null` if do not exist).

--- a/docs/platform/identities/register.md
+++ b/docs/platform/identities/register.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.identities.register('user')`    
+**Usage**: `client.platform.identities.register('user')`    
 **Description**: This method will create an `application` or `user` new identity for you. 
 
 Parameters: 
@@ -7,4 +7,4 @@ Parameters:
 |-------------------|---------|------------------	| -----------------------------------------------------------------	|
 | **identityType**  | string  | no (default: 'USER')| Allow to register a user (`USER`) or an application (`APPLICATION`) |
 
-**Example**: `await sdk.platform.identities.register('APPLICATION')`
+**Example**: `await client.platform.identities.register('APPLICATION')`

--- a/docs/platform/names/get.md
+++ b/docs/platform/names/get.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.names.get(name)`    
+**Usage**: `client.platform.names.get(name)`    
 **Description**: This method will allow you to fetch back a DPNS records from its humanized name. 
 
 Parameters: 
@@ -7,6 +7,6 @@ Parameters:
 |---------------------------|-----------|----------------| ----------------------------------------------------------------------------- |
 | **name**                  | String    | yes            | An alphanumeric (2-63) value used for human-identification (can contains `-`) |
 
-**Example**: `await sdk.platform.names.get('alice')`
+**Example**: `await client.platform.names.get('alice')`
 
 Returns : Identity (or `null` if do not exist).

--- a/docs/platform/names/register.md
+++ b/docs/platform/names/register.md
@@ -1,4 +1,4 @@
-**Usage**: `sdk.platform.names.register(name, identity)`    
+**Usage**: `client.platform.names.register(name, identity)`    
 **Description**: This method will create a DPNS record matching your identity to the user or appname defined.
 
 Parameters: 
@@ -9,4 +9,4 @@ Parameters:
 | **identity**              | Identity  | yes            | A valid [registered identity](/platform/identities/register.md)               |
 
 
-**Example**: `await sdk.platform.identities.register('alice', identity)`
+**Example**: `await client.platform.identities.register('alice', identity)`

--- a/docs/usage/dapi.md
+++ b/docs/usage/dapi.md
@@ -5,7 +5,7 @@ DAPI (Decentralized API) is a distributed and decentralized endpoints provided b
 ## Get the DAPI-Client instance
 
 ```js
- const dapi = sdk.getDAPIInstance();
+ const dapi = client.getDAPIInstance();
 ```
 
 The usage is then [described here](https://dashplatform.readme.io/docs/explanation-dapi).

--- a/docs/wallet/about-wallet-lib.md
+++ b/docs/wallet/about-wallet-lib.md
@@ -1,7 +1,7 @@
 ### About Wallet-lib 
 
-When DashJS.Client is initiated with a `mnemonic` property, a wallet instance is automatically created accessible via `sdk.wallet` as well as an `sdk.account` instance. 
+When Dash.Client is initiated with a `mnemonic` property, a wallet instance is automatically created accessible via `client.wallet` as well as an `client.account` instance. 
 
-In order to ensure the sync-up with the network has happened, you will need to wait for the method `sdk.isReady()` to resolve. 
+In order to ensure the sync-up with the network has happened, you will need to wait for the method `client.isReady()` to resolve. 
 
 You will find else where the [complete documentation of Wallet-lib](https://github.com/dashevo/wallet-lib), as we only cover the most basic pieces in this documentation.

--- a/docs/wallet/accounts.md
+++ b/docs/wallet/accounts.md
@@ -4,11 +4,11 @@ A Wallet is actually a holders of multiple Account that hold the keys needed to 
 So the first thing will be on accessing your account : 
 
 ```js
-const sdk = new DashJS.Client({
+const client = new Dash.Client({
   mnemonic: "maximum blast eight orchard waste wood gospel siren parent deer athlete impact",
 });
-sdk.isReady().then(()=>{
-  const {account} = sdk;
+client.isReady().then(()=>{
+  const {account} = client;
   // Do something with account
 });
 ```

--- a/docs/wallet/signing-encrypt.md
+++ b/docs/wallet/signing-encrypt.md
@@ -1,22 +1,22 @@
 ## Sign a Transaction/Transition a message
 
 ```js
-const tx = new DashJS.Transaction({
+const tx = new Dash.Transaction({
 //txOpts
 });
-const signedTx = sdk.account.sign(tx);
+const signedTx = client.account.sign(tx);
 ```
 
 ## Encrypt a message
 
 ```js
   const message = 'Something';
-  const signedMessage = sdk.account.encrypt('AES',message,'secret');
+  const signedMessage = client.account.encrypt('AES',message,'secret');
 ```
 
 ## Decrypt a message
 
 ```js
 const encrypted = 'U2FsdGVkX19JLa+1UpbMcut1/QFWLMlKUS+iqz+7Wl4=';
-const message = sdk.account.decrypt('AES',encrypted,'secret');
+const message = client.account.decrypt('AES',encrypted,'secret');
 ```

--- a/examples/node/create-and-fund-wallet.js
+++ b/examples/node/create-and-fund-wallet.js
@@ -1,12 +1,12 @@
-const DashJS = require('dash');
-const sdkOpts = {
+const Dash = require('dash');
+const clientOpts = {
   network: 'testnet',
   mnemonic: null,// Will generate a new address, you should keep it.
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const displayFundingAddress = async function () {
-  const {account, wallet} = sdk;
+  const {account, wallet} = client;
 
   const mnemonic = wallet.exportWallet();
   const address = account.getUnusedAddress().address;
@@ -16,11 +16,11 @@ const displayFundingAddress = async function () {
   // Fund this address using the faucet : http://devnet-evonet-1117662964.us-west-2.elb.amazonaws.com/
 };
 const onReceivedTransaction = function(data){
-  const {account} = sdk;
+  const {account} = client;
   console.log('Received tx',data.txid);
   console.log('Total pending confirmation',  account.getUnconfirmedBalance());
   console.log('Total balance',  account.getTotalBalance());
 }
-sdk.account.events.on('FETCHED/UNCONFIRMED_TRANSACTION',onReceivedTransaction)
-sdk.isReady().then(displayFundingAddress);
+client.account.on('FETCHED/UNCONFIRMED_TRANSACTION',onReceivedTransaction)
+client.isReady().then(displayFundingAddress);
 

--- a/examples/node/register-identity.js
+++ b/examples/node/register-identity.js
@@ -1,14 +1,14 @@
-const DashJS = require('dash');
-const sdkOpts = {
+const Dash = require('dash');
+const clientOpts = {
   network: 'testnet',
   mnemonic:'your mnemonic here'
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const createIdentity = async function () {
-  await sdk.isReady();
+  await client.isReady();
 
-  let platform = sdk.platform;
+  let platform = client.platform;
 
   platform
       .identities

--- a/examples/node/register-name.js
+++ b/examples/node/register-name.js
@@ -1,14 +1,14 @@
-const DashJS = require('dash');
-const sdkOpts = {
+const Dash = require('dash');
+const clientOpts = {
   network: 'testnet',
   mnemonic:'your mnemonic here'
 };
 const identityId = 'your identity id';
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const registerName = async function () {
-  let platform = sdk.platform;
-  await sdk.isReady();
+  let platform = client.platform;
+  await client.isReady();
 
   const identity = await platform.identities.get(identityId);
   const nameRegistration = await platform.names.register('alice', identity);

--- a/examples/node/retrieve-contract.js
+++ b/examples/node/retrieve-contract.js
@@ -1,13 +1,13 @@
-const DashJS = require('dash');
+const Dash = require('dash');
 
-const sdkOpts = {
+const clientOpts = {
   network: 'testnet'
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const getContract = async function () {
-  let platform = sdk.platform;
-  await sdk.isReady();
+  let platform = client.platform;
+  await client.isReady();
 
   platform
       .contracts

--- a/examples/node/retrieve-documents.js
+++ b/examples/node/retrieve-documents.js
@@ -1,13 +1,13 @@
-const DashJS = require('dash');
+const Dash = require('dash');
 
-const sdkOpts = {
+const clientOpts = {
   network: 'testnet'
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const getDocuments = async function () {
-  let platform = sdk.platform;
-  await sdk.isReady();
+  let platform = client.platform;
+  await client.isReady();
 
   const queryOpts = {
     where: [

--- a/examples/node/retrieve-identity.js
+++ b/examples/node/retrieve-identity.js
@@ -1,13 +1,13 @@
-const DashJS = require('dash');
+const Dash = require('dash');
 
-const sdkOpts = {
+const clientOpts = {
   network: 'testnet'
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
 const getIdentity = async function () {
-  let platform = sdk.platform;
-  await sdk.isReady();
+  let platform = client.platform;
+  await client.isReady();
 
   platform
       .identities

--- a/examples/node/retrieve-name.js
+++ b/examples/node/retrieve-name.js
@@ -1,11 +1,11 @@
-const DashJS = require('dash');
+const Dash = require('dash');
 
-const sdkOpts = {
+const clientOpts = {
   network: 'testnet'
 };
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
-const platform = sdk.platform;
+const platform = client.platform;
 
 async function retrieveName(){
   const user = await platform.names.get('alice');

--- a/examples/node/sign-and-verify-messages.js
+++ b/examples/node/sign-and-verify-messages.js
@@ -1,16 +1,16 @@
-const DashJS = require('dash');
+const Dash = require('dash');
 
-const sdkOpts = {
+const clientOpts = {
   network: 'testnet',
   mnemonic: null,
 };
 
-const sdk = new DashJS.Client(sdkOpts);
+const client = new Dash.Client(clientOpts);
 
-const message = new DashJS.Message('hello, world');
+const message = new Dash.Core.Message('hello, world');
 
 const signAndVerify = async function () {
-  const {account, wallet} = sdk;
+  const {account, wallet} = client;
 
   const mnemonic = wallet.exportWallet();
   console.log('Mnemonic:', mnemonic);
@@ -23,5 +23,5 @@ const signAndVerify = async function () {
   const verify = message.verify(idAddress, signed.toString());
   console.log(verify);
 };
-sdk.isReady().then(signAndVerify);
+client.isReady().then(signAndVerify);
 

--- a/examples/web/usage.web.js
+++ b/examples/web/usage.web.js
@@ -8,9 +8,9 @@ const opts = {
     }
   }
 };
-const sdk = new DashJS.Client(opts);
-sdk.isReady().then(()=>{
-  const {account, platform} = sdk;
+const client = new Dash.Client(opts);
+client.isReady().then(()=>{
+  const {account, platform} = client;
 
   async function sendPayment() {
     const tx = await account.createTransaction({recipient: 'yNPbcFfabtNmmxKdGwhHomdYfVs6gikbPf', satoshis: 12000});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "dist/dash.cjs.min.js",
   "unpkg": "dist/dash.min.js",
-  "types": "src/DashJS/DashJS.d.ts",
+  "types": "src/SDK/SDK.d.ts",
   "scripts": {
     "start:dev": "nodemon --exec 'npm run build:dev && npm run test:ts'",
     "build:dev": "webpack -d --display-error-details --progress",

--- a/src/SDK/Client/Client.spec.ts
+++ b/src/SDK/Client/Client.spec.ts
@@ -3,21 +3,21 @@ import {Client} from "./index";
 import 'mocha';
 
 const mnemonic = 'agree country attract master mimic ball load beauty join gentle turtle hover';
-describe('DashJS - Client', function suite() {
+describe('Dash - Client', function suite() {
   this.timeout(10000);
   it('should provide expected class', function () {
     expect(Client.name).to.be.equal('Client');
     expect(Client.constructor.name).to.be.equal('Function');
   });
   it('should be instantiable', function () {
-    const sdk = new Client();
-    expect(sdk).to.exist;
-    expect(sdk.network).to.be.equal('testnet');
-    expect(sdk.getDAPIInstance().constructor.name).to.be.equal('DAPIClient');
+    const client = new Client();
+    expect(client).to.exist;
+    expect(client.network).to.be.equal('testnet');
+    expect(client.getDAPIInstance().constructor.name).to.be.equal('DAPIClient');
   });
   it('should not initiate wallet lib without mnemonic', function () {
-    const sdk = new Client();
-    expect(sdk.wallet).to.be.equal(undefined);
+    const client = new Client();
+    expect(client.wallet).to.be.equal(undefined);
   });
   it('should initiate wallet-lib with a mnemonic', async ()=>{
     const client = new Client({mnemonic});

--- a/src/SDK/Client/Platform/Platform.spec.ts
+++ b/src/SDK/Client/Platform/Platform.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import {Platform} from "./index";
 import 'mocha';
 
-describe('DashJS - Platform', () => {
+describe('Dash - Platform', () => {
 
   it('should provide expected class', function () {
     expect(Platform.name).to.be.equal('Platform')

--- a/src/SDK/SDK.d.ts
+++ b/src/SDK/SDK.d.ts
@@ -14,7 +14,7 @@ import {
     PrivateKey as _PrivateKey
 } from '@dashevo/dashcore-lib';
 
-export declare namespace DashJS {
+export declare namespace Dash {
     export type Transaction = _Transaction;
 
     export type Address = _Address;

--- a/src/SDK/SDK.spec.ts
+++ b/src/SDK/SDK.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import SDK from "./index";
 import 'mocha';
 
-describe('DashJS', () => {
+describe('Dash', () => {
 
   it('should provide expected class', function () {
     expect(SDK).to.have.property('Client');

--- a/tests/functional/index.js
+++ b/tests/functional/index.js
@@ -1,23 +1,23 @@
 const {expect} = require('chai');
-const DashJS = require('../../dist/dash.cjs.min');
+const Dash = require('../../dist/dash.cjs.min');
 
 describe('SDK', function suite() {
   this.timeout(10000);
   let instanceWithoutWallet = {};
   let instanceWithWallet = {};
   it('should provide expected class', function () {
-    expect(DashJS).to.have.property('Client');
-    expect(DashJS.Client.constructor.name).to.be.equal('Function')
+    expect(Dash).to.have.property('Client');
+    expect(Dash.Client.constructor.name).to.be.equal('Function')
   });
   it('should create an instance', function (done) {
-    instanceWithoutWallet = new DashJS.Client();
+    instanceWithoutWallet = new Dash.Client();
     expect(instanceWithoutWallet.network).to.equal('testnet');
     expect(instanceWithoutWallet.apps).to.deep.equal({
           dpns: { contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3' }
         }
     );
 
-    instanceWithWallet = new DashJS.Client({mnemonic:null});
+    instanceWithWallet = new Dash.Client({mnemonic:null});
     expect(instanceWithWallet.network).to.equal('testnet');
     expect(instanceWithWallet.apps).to.deep.equal({
           dpns: { contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3' }
@@ -31,8 +31,8 @@ describe('SDK', function suite() {
     const idKey = account.getIdentityHDKey();
     // This transforms from a Wallet-Lib.PrivateKey to a Dashcore-lib.PrivateKey.
     // It will quickly be annoying to perform this, and we therefore need to find a better solution for that.
-    const privateKey = DashJS.Core.PrivateKey(idKey.privateKey);
-    const message = DashJS.Core.Message('hello, world');
+    const privateKey = Dash.Core.PrivateKey(idKey.privateKey);
+    const message = Dash.Core.Message('hello, world');
     const signed = message.sign(privateKey);
     const verify = message.verify(idKey.privateKey.toAddress().toString(), signed.toString());
     expect(verify).to.equal(true);

--- a/tests/z_integrations/user-flow-1.js
+++ b/tests/z_integrations/user-flow-1.js
@@ -1,10 +1,10 @@
 const {expect} = require('chai');
-const DashJS = require('../../dist/dash.cjs.min.js');
+const Dash = require('../../dist/dash.cjs.min.js');
 const fixtures = require('../fixtures/user-flow-1');
 const Chance = require('chance');
 const chance = new Chance();
 
-let sdkInstance;
+let clientInstance;
 let hasBalance=false;
 let hasDuplicate=true;
 let createdIdentityId;
@@ -14,7 +14,7 @@ const year = chance.birthday({string: true}).slice(-2);
 const firstname = chance.first();
 const username = `test-${firstname}${year}`;
 
-const sdkOpts = {
+const clientOpts = {
   network: fixtures.network,
   mnemonic: fixtures.mnemonic
 };
@@ -22,45 +22,45 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
   this.timeout(240000);
 
   it('should init a Client', async () => {
-    sdkInstance = new DashJS.Client(sdkOpts);
-    expect(sdkInstance.network).to.equal('testnet');
-    expect(sdkInstance.accountIndex).to.equal(0);
-    expect(sdkInstance.apps).to.deep.equal({dpns: {contractId: "77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3"}});
-    expect(sdkInstance.wallet.network).to.equal('testnet');
-    expect(sdkInstance.wallet.offlineMode).to.equal(false);
-    expect(sdkInstance.wallet.mnemonic).to.equal(fixtures.mnemonic);
-    expect(sdkInstance.wallet.walletId).to.equal('6afaad2189');
-    expect(sdkInstance.account.index).to.equal(0);
-    expect(sdkInstance.account.walletId).to.equal('6afaad2189');
-    expect(sdkInstance.account.getUnusedAddress().address).to.equal('yj8sq7ogzz6JtaxpBQm5Hg9YaB5cKExn5T');
+    clientInstance = new Dash.Client(clientOpts);
+    expect(clientInstance.network).to.equal('testnet');
+    expect(clientInstance.accountIndex).to.equal(0);
+    expect(clientInstance.apps).to.deep.equal({dpns: {contractId: "77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3"}});
+    expect(clientInstance.wallet.network).to.equal('testnet');
+    expect(clientInstance.wallet.offlineMode).to.equal(false);
+    expect(clientInstance.wallet.mnemonic).to.equal(fixtures.mnemonic);
+    expect(clientInstance.wallet.walletId).to.equal('6afaad2189');
+    expect(clientInstance.account.index).to.equal(0);
+    expect(clientInstance.account.walletId).to.equal('6afaad2189');
+    expect(clientInstance.account.getUnusedAddress().address).to.equal('yj8sq7ogzz6JtaxpBQm5Hg9YaB5cKExn5T');
 
-    expect(sdkInstance.platform.dpp).to.exist;
-    expect(sdkInstance.platform.client).to.exist;
+    expect(clientInstance.platform.dpp).to.exist;
+    expect(clientInstance.platform.client).to.exist;
   });
   it('should be ready quickly', (done) => {
     let timer = setTimeout(() => {
       done(new Error('Should have been initialized in time'));
     }, 15000);
-    sdkInstance.isReady().then(() => {
+    clientInstance.isReady().then(() => {
       clearTimeout(timer);
-      expect(sdkInstance.account.state).to.deep.equal({isInitialized: true, isReady: true, isDisconnecting: false});
-      expect(sdkInstance.state).to.deep.equal({isReady: true, isAccountReady: true});
-      expect(sdkInstance.apps['dpns']).to.exist;
-      expect(sdkInstance.apps['dpns'].contractId).to.equal('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3');
-      expect(sdkInstance.apps['dpns'].contractId).to.equal('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3');
+      expect(clientInstance.account.state).to.deep.equal({isInitialized: true, isReady: true, isDisconnecting: false});
+      expect(clientInstance.state).to.deep.equal({isReady: true, isAccountReady: true});
+      expect(clientInstance.apps['dpns']).to.exist;
+      expect(clientInstance.apps['dpns'].contractId).to.equal('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3');
+      expect(clientInstance.apps['dpns'].contractId).to.equal('77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3');
       return done();
     })
   });
   it('should have a balance', function (done) {
-    const balance = (sdkInstance.account.getTotalBalance());
+    const balance = (clientInstance.account.getTotalBalance());
     if(balance<10000){
-      return done(new Error(`You need to fund this address : ${sdkInstance.account.getUnusedAddress().address}. Insuffisiant balance: ${balance}`));
+      return done(new Error(`You need to fund this address : ${clientInstance.account.getUnusedAddress().address}. Insuffisiant balance: ${balance}`));
     }
     hasBalance = true;
     return done();
   });
   it('should check it\'s DPNS reg is available' , async function () {
-    const getDocument = await sdkInstance.platform.names.get(username);
+    const getDocument = await clientInstance.platform.names.get(username);
     expect(getDocument).to.equal(null);
     hasDuplicate = false;
   });
@@ -68,7 +68,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
     if(!hasBalance){
       throw new Error('Insufficient balance to perform this test')
     }
-    createdIdentityId = await sdkInstance.platform.identities.register();
+    createdIdentityId = await clientInstance.platform.identities.register();
     expect(createdIdentityId).to.not.equal(null);
     expect(createdIdentityId.length).to.gte(42);
     expect(createdIdentityId.length).to.lte(44);
@@ -78,7 +78,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
     if(!createdIdentityId){
       throw new Error('Can\'t perform the test. Failed to create identity');
     }
-    const fetchIdentity = await sdkInstance.platform.identities.get(createdIdentityId);
+    const fetchIdentity = await clientInstance.platform.identities.get(createdIdentityId);
 
     expect(fetchIdentity).to.exist;
     expect(fetchIdentity.id).to.equal(createdIdentityId);
@@ -92,7 +92,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
     if(hasDuplicate){
       throw new Error(`Duplicate username ${username} registered. Skipping.`)
     }
-    const createDocument = await sdkInstance.platform.names.register(username, createdIdentity);
+    const createDocument = await clientInstance.platform.names.register(username, createdIdentity);
     expect(createDocument.action).to.equal(1);
     expect(createDocument.type).to.equal('domain');
     expect(createDocument.userId).to.equal(createdIdentityId);
@@ -105,7 +105,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
     if(!createdIdentity){
       throw new Error('Can\'t perform the test. Failed to fetch identity & did not reg name');
     }
-    const [doc] = await sdkInstance.platform.documents.get('dpns.domain', {where:[
+    const [doc] = await clientInstance.platform.documents.get('dpns.domain', {where:[
         ["normalizedParentDomainName","==","dash"],
         ["normalizedLabel","==",username.toLowerCase()],
       ]})
@@ -117,7 +117,7 @@ describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite
     expect(doc.data.normalizedParentDomainName).to.equal('dash');
   });
   it('should disconnect', async function () {
-    await sdkInstance.disconnect();
+    await clientInstance.disconnect();
   });
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ const webConfig = Object.assign({}, baseConfig, {
   output: {
     ...baseConfig.output,
     libraryTarget: 'umd',
-    library: 'DashJS',
+    library: 'Dash',
     filename: 'dash.min.js',
     // fixes ReferenceError: window is not defined
     globalObject: "(typeof self !== 'undefined' ? self : this)"


### PR DESCRIPTION
### Issue being fixed or implemented  

This mostly executes wordings changes reflecting the wish to explicitly call this library the Dash SDK that contains a Client (amongst other Primitives). 
But our reference were misleading to a `sdk` instance that were representing actually the client. 
In the same way, we renamed `DashJS` mentions in code examples for `Dash` (const Dash = require('Dash'))

### What was done  

- Breaking: updated exported module for web environment from `DashJS` to `Dash`
- Doc: updated "DashJS" to "Dash"
- Doc: updated "sdk"to "client"
- Doc: update Core Primitives path from Dash.* to Dash.Core.* (e.g : Dash.PrivateKey -> Dash.Core.PrivateKey)

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
