### PR TITLE
fix: DPP 0.12 identity create signing

### DIFF
--- a/examples/node/register-identity.js
+++ b/examples/node/register-identity.js
@@ -12,7 +12,7 @@ const createIdentity = async function () {
 
   platform
       .identities
-      .register('user')
+      .register()
       .then((identityId) => {
         console.log({identityId});
       });

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/dashevo/DashJS#readme",
   "dependencies": {
-    "@dashevo/dapi-client": "~0.11.0",
+    "@dashevo/dapi-client": "~0.12.0",
     "@dashevo/dashcore-lib": "^0.18.0",
-    "@dashevo/dpp": "~0.11.1",
     "@dashevo/wallet-lib": "^6.0.1",
+    "@dashevo/dpp": "~0.12.1",
     "bs58": "^4.0.1"
   },
   "devDependencies": {

--- a/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/src/SDK/Client/Platform/methods/identities/register.ts
@@ -99,7 +99,7 @@ export async function register(this: Platform): Promise<any> {
         });
         // FIXME : Need dpp to be a dependency of wallet-lib to deal with signing IdentityPublicKey (validation)
         // account.sign(identityPublicKeyModel, identityPrivateKey);
-        identityCreateTransition.sign(identityPublicKeyModel, identityPrivateKey);
+        await identityCreateTransition.signByPrivateKey(identityPrivateKey);
         // @ts-ignore
         await client.applyStateTransition(identityCreateTransition);
 


### PR DESCRIPTION
### Issue being fixed or implemented  

Make it possible to register an identity on Evonet 0.12.

### What was done  

Update dependencies and ID create ST signing

### How Has This Been Tested?

Ran register identity example.

### Notes  

**_This also requires an updated wallet-lib dependency which is not available on npm yet. Tested using the develop branch from GitHub_**

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
