### PR TITLE
fix: changed dpp.documents (undefined) to dpp.document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# [3.0.1](https://github.com/dashevo/DashJS/compare/v3.0.1...v3.0.0) (2020-04-27)
+
+- **fix**:
+  - changed dpp.documents (undefined) to dpp.document (#48)
+
+# [3.0.0](https://github.com/dashevo/DashJS/compare/v3.0.0...v2.0.0) (2020-04-24)
+
+- **breaking:**
+  - Identity registration will use HDKeys(0) instead 1 (https://github.com/dashevo/DashJS/pull/41/commits/4bbc54d265c679affbd043b03a88f8ed2f1d52fb)
+  - contract.broadcast() now returns dataContract (https://github.com/dashevo/DashJS/pull/41/commits/6f7e9225f317525388fb7701619da74b5d76222b#diff-486b5234782255b516fe9c1868c7d3b0R19)
+  - identities.broadcast() now return identity (https://github.com/dashevo/DashJS/pull/41/commits/4bbc54d265c679affbd043b03a88f8ed2f1d52fb#diff-27f47e1bd838b3993aed5eaa396a00e5R90)
+  - document.broadcast() creation is now performed via passing documents to be created in an array of property create. `{create:[document]}` (https://github.com/dashevo/DashJS/commit/91127d774a339c4204891f5863c91a64d521ddb8#diff-0202b3d53936b94585a8c0cfa0481bccR10)
+
+- **feat**:
+  - added replacement of a document. (#41)
+  - added deletion of a document (#41)
+
+- **impr**: 
+  - update to dpp 0.12 (#41)
+
+- **fix**:
+  - properly release (throw) catched error (#41)
+
+- **Chore, Docs & Tests:**
+  - bumped wallet-lib to 6.1 (#41)
+ 
 # [2.0.0](https://github.com/dashevo/DashJS/compare/v2.0.0...v1.1.2) (2020-03-27)
 
 - **breaking:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "dist/dash.cjs.min.js",
   "unpkg": "dist/dash.min.js",

--- a/src/SDK/Client/Platform/methods/documents/broadcast.ts
+++ b/src/SDK/Client/Platform/methods/documents/broadcast.ts
@@ -14,8 +14,8 @@ import broadcastStateTransition from '../../broadcastStateTransition';
 export default async function broadcast(this: Platform, documents: { create: any[], replace: any[], delete: any[]}, identity: any): Promise<any> {
     const { dpp } = this;
 
-    const documentsBatchTransition = dpp.documents.createStateTransition(documents);
-
+    const documentsBatchTransition = dpp.document.createStateTransition(documents);
+    
     await broadcastStateTransition(this, documentsBatchTransition, identity);
 
     return documents;


### PR DESCRIPTION
### Issue being fixed or implemented  

I get the following error without this change when using `documents.broadcast`:
``` UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'createStateTransition' of undefined```

### What was done  

`dpp.documents.createStateTransition` -> 
`dpp.document.createStateTransition`

### How Has This Been Tested?

Tested locally. Submitted several create documents successfully to contract `5wpZAEWndYcTeuwZpkmSa8s49cHXU5q2DhdibesxFSu8`

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
