### PR TITLE
refactor: Client options now have `wallet` field to pre-configure wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ const Dash = require("dash");
 
 const client = new Dash.Client({
   network: "testnet",
-  mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  wallet: {
+    mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  },
 });
 
 client.isReady().then(async () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,9 @@ const Dash = require("dash");
 
 const client = new Dash.Client({
   network: "testnet",
-  mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  wallet: {
+    mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  },
 });
 
 client.isReady().then(async () => {

--- a/docs/examples/fetch-an-identity-from-its-name.md
+++ b/docs/examples/fetch-an-identity-from-its-name.md
@@ -5,7 +5,9 @@ You will then be able to directly recover an identity from its names. See below:
 
 ```js
 const client = new Dash.Client({
-  mnemonic: ''// Your app mnemonic, which holds the app identity
+  wallet: {
+    mnemonic: '', // Your app mnemonic, which holds the app identity
+  },
 });
 
 // This is the name previously registered in DPNS.

--- a/docs/examples/fetch-an-identity-from-its-name.md
+++ b/docs/examples/fetch-an-identity-from-its-name.md
@@ -6,7 +6,7 @@ You will then be able to directly recover an identity from its names. See below:
 ```js
 const client = new Dash.Client({
   wallet: {
-    mnemonic: '', // Your app mnemonic, which holds the app identity
+    mnemonic: '', // Your app mnemonic, which holds the identity
   },
 });
 

--- a/docs/examples/generate-a-new-mnemonic.md
+++ b/docs/examples/generate-a-new-mnemonic.md
@@ -5,13 +5,15 @@ Below, you will be proposed two options allowing you to create a new mnemonic, d
 
 ## Dash.Client
 
-By passing `null` to the mnemonic value, you can get Wallet-lib to generate a new mnemonic for you. 
+By passing `null` to the mnemonic value of the wallet options, you can get Wallet-lib to generate a new mnemonic for you. 
 
 ```js
 const Dash = require("dash");
 const client = new Dash.Client({
   network: "testnet",
-  mnemonic: null,
+  wallet: {
+    mnemonic: null,
+  },
 });
 const mnemonic = client.wallet.exportWallet();
 console.log({mnemonic});

--- a/docs/examples/publishing-a-new-contract.md
+++ b/docs/examples/publishing-a-new-contract.md
@@ -12,7 +12,9 @@ and [attached to a name](https://dashplatform.readme.io/docs/tutorial-register-a
 ```js
 const schema = {};// You JSON schema defining the app.
 const client = new Dash.Client({
-  mnemonic: ''// Your app mnemonic, which holds the app identity
+  wallet: {
+    mnemonic: '', // Your app mnemonic, which holds the app identity
+  },
 });
 
 // This is the name previously registered in DPNS.
@@ -40,7 +42,9 @@ const schema = {};// You JSON schema defining the app.
 
 // This is the name previously registered in DPNS.
 const client = new Dash.Client({
-  mnemonic: "",// Your app mnemonic, which holds the app identity
+  wallet: {
+    mnemonic: "", // Your app mnemonic, which holds the app identity
+  },
   apps:{
     myapp:{
       contractId:""// The registered contract id    

--- a/docs/examples/publishing-a-new-contract.md
+++ b/docs/examples/publishing-a-new-contract.md
@@ -43,7 +43,7 @@ const schema = {};// You JSON schema defining the app.
 // This is the name previously registered in DPNS.
 const client = new Dash.Client({
   wallet: {
-    mnemonic: "", // Your app mnemonic, which holds the app identity
+    mnemonic: "", // Your app mnemonic, which holds the identity
   },
   apps:{
     myapp:{

--- a/docs/examples/publishing-a-new-contract.md
+++ b/docs/examples/publishing-a-new-contract.md
@@ -13,7 +13,7 @@ and [attached to a name](https://dashplatform.readme.io/docs/tutorial-register-a
 const schema = {};// You JSON schema defining the app.
 const client = new Dash.Client({
   wallet: {
-    mnemonic: '', // Your app mnemonic, which holds the app identity
+    mnemonic: '', // Your app mnemonic, which holds the identity
   },
 });
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,7 +6,6 @@ Having [NodeJS](https://nodejs.org/) installed, just type :
 
 ```bash
 npm install dash
-## Initialize
 ```
 ## Initialization
 
@@ -22,7 +21,9 @@ const opts = {
       schema: require('schema.json')
     },
   },
-  mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  wallet: {
+    mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  },
 };
 const client = new Dash.Client(opts);
 client.isReady().then(()=>{

--- a/docs/getting-started/with-typescript.md
+++ b/docs/getting-started/with-typescript.md
@@ -1,12 +1,14 @@
 In order to use Dash SDK with TypeScript.    
 
-Create a index.ts file  
+Create an index.ts file  
 
 ```js
 import Dash from 'dash';
 const clientOpts = {
   network: 'testnet',
-  mnemonic: null,// Will generate a new address, you should keep it.
+  wallet: {
+    mnemonic: null, // Will generate a new address, you should keep it.
+  },
 };
 const client = new Dash.Client(clientOpts);
 

--- a/docs/wallet/accounts.md
+++ b/docs/wallet/accounts.md
@@ -5,7 +5,9 @@ So the first thing will be on accessing your account :
 
 ```js
 const client = new Dash.Client({
-  mnemonic: "maximum blast eight orchard waste wood gospel siren parent deer athlete impact",
+  wallet: {
+    mnemonic: "maximum blast eight orchard waste wood gospel siren parent deer athlete impact",
+  },
 });
 client.isReady().then(()=>{
   const {account} = client;

--- a/examples/node/create-and-fund-wallet.js
+++ b/examples/node/create-and-fund-wallet.js
@@ -1,7 +1,9 @@
 const Dash = require('dash');
 const clientOpts = {
   network: 'testnet',
-  mnemonic: null,// Will generate a new address, you should keep it.
+  wallet: {
+    mnemonic: null, // Will generate a new address, you should keep it.
+  },
 };
 const client = new Dash.Client(clientOpts);
 

--- a/examples/node/register-contract.js
+++ b/examples/node/register-contract.js
@@ -2,7 +2,9 @@ const DashJS = require('dash');
 
 const sdkOpts = {
   network: 'testnet',
-  mnemonic:'your mnemonic here'
+  wallet: {
+    mnemonic: 'your mnemonic here',
+  },
 };
 const sdk = new DashJS.Client(sdkOpts);
 

--- a/examples/node/register-identity.js
+++ b/examples/node/register-identity.js
@@ -1,7 +1,9 @@
 const Dash = require('dash');
 const clientOpts = {
   network: 'testnet',
-  mnemonic:'your mnemonic here'
+  wallet: {
+    mnemonic: 'your mnemonic here',
+  },
 };
 const client = new Dash.Client(clientOpts);
 

--- a/examples/node/register-name.js
+++ b/examples/node/register-name.js
@@ -1,7 +1,9 @@
 const Dash = require('dash');
 const clientOpts = {
   network: 'testnet',
-  mnemonic:'your mnemonic here'
+  wallet: {
+    mnemonic: 'your mnemonic here',
+  },
 };
 const identityId = 'your identity id';
 const client = new Dash.Client(clientOpts);

--- a/examples/node/sign-and-verify-messages.js
+++ b/examples/node/sign-and-verify-messages.js
@@ -2,7 +2,9 @@ const Dash = require('dash');
 
 const clientOpts = {
   network: 'testnet',
-  mnemonic: null,
+  wallet: {
+    mnemonic: null,
+  },
 };
 
 const client = new Dash.Client(clientOpts);

--- a/examples/web/usage.web.js
+++ b/examples/web/usage.web.js
@@ -1,7 +1,9 @@
 const network = "testnet";
 const opts = {
   network,
-  mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  wallet: {
+    mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
+  },
   apps: {
     dashpay: {
     contractId: ''// Provide the dashpay contract id here

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check-package:version": "test $(jq -r .version package.json) = $(jq -r .version package-lock.json)",
     "test": "npm run test:ts && npm run build:prod && npm run test:js",
     "test:ts": "mocha -r ts-node/register \"src/**/*.spec.ts\"",
-    "test:js": "mocha --recursive tests/**/*.js"
+    "test:js": "mocha --recursive tests/**/*.js",
+    "install": "npm run build:dev"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:ts && npm run build:prod && npm run test:js",
     "test:ts": "mocha -r ts-node/register \"src/**/*.spec.ts\"",
     "test:js": "mocha --recursive tests/**/*.js",
-    "install": "npm run build:dev"
+    "prepare": "npm run build:dev"
   },
   "repository": {
     "type": "git",

--- a/src/SDK/Client/Client.spec.ts
+++ b/src/SDK/Client/Client.spec.ts
@@ -20,7 +20,7 @@ describe('Dash - Client', function suite() {
     expect(client.wallet).to.be.equal(undefined);
   });
   it('should initiate wallet-lib with a mnemonic', async ()=>{
-    const client = new Client({mnemonic});
+    const client = new Client({ wallet: { mnemonic } });
     await client.isReady();
     expect(client.wallet).to.exist;
     expect(client.wallet!.offlineMode).to.be.equal(false);

--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -23,14 +23,14 @@ export type DPASchema = object
  *
  * @param {[string]?} [seeds] - wallet seeds
  * @param {Network? | string?} [network] - evonet network
- * @param {Mnemonic? | string? | null?} [mnemonic] - mnemonic passphrase
+ * @param {Wallet.Options? | null?} [wallet] - wallet options
  * @param {SDKApps?} [apps] - applications
  * @param {number?} [accountIndex] - account index number
  */
 export interface ClientOpts {
     seeds?: [string];
     network?: Network | string,
-    mnemonic?: Mnemonic | string | null,
+    wallet?: Wallet.Options | null,
     apps?: ClientApps,
     accountIndex?: number,
 }
@@ -101,10 +101,11 @@ export class Client {
                 network: this.network
             })
         };
+
         // We accept null as parameter for a new generated mnemonic
-        if (opts.mnemonic !== undefined) {
+        if (opts.wallet !== undefined) {
             // @ts-ignore
-            this.wallet = new Wallet({...opts, transport: this.clients.dapi});
+            this.wallet = new Wallet({...opts.wallet, transport: this.clients.dapi});
             if (this.wallet) {
                 let accountIndex = (opts.accountIndex !== undefined) ? opts.accountIndex : 0;
                 this.account = this.wallet.getAccount({index: accountIndex});

--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -105,7 +105,7 @@ export class Client {
         // We accept null as parameter for a new generated mnemonic
         if (opts.wallet !== undefined) {
             // @ts-ignore
-            this.wallet = new Wallet({...opts.wallet, transport: this.clients.dapi});
+            this.wallet = new Wallet({...opts.wallet, transporter: this.clients.dapi});
             if (this.wallet) {
                 let accountIndex = (opts.accountIndex !== undefined) ? opts.accountIndex : 0;
                 this.account = this.wallet.getAccount({index: accountIndex});

--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -105,7 +105,16 @@ export class Client {
         // We accept null as parameter for a new generated mnemonic
         if (opts.wallet !== undefined) {
             // @ts-ignore
-            this.wallet = new Wallet({...opts.wallet, transporter: this.clients.dapi});
+            this.wallet = new Wallet({
+                transporter: {
+                    seeds: seeds,
+                    timeout: 1000,
+                    retries: 5,
+                    network: this.network,
+                    type: 'dapi',
+                },
+                ...opts.wallet,
+            });
             if (this.wallet) {
                 let accountIndex = (opts.accountIndex !== undefined) ? opts.accountIndex : 0;
                 this.account = this.wallet.getAccount({index: accountIndex});

--- a/tests/functional/index.js
+++ b/tests/functional/index.js
@@ -17,7 +17,11 @@ describe('SDK', function suite() {
         }
     );
 
-    instanceWithWallet = new Dash.Client({mnemonic:null});
+    instanceWithWallet = new Dash.Client({
+      wallet: {
+        mnemonic: null,
+      },
+    });
     expect(instanceWithWallet.network).to.equal('testnet');
     expect(instanceWithWallet.apps).to.deep.equal({
           dpns: { contractId: '295xRRRMGYyAruG39XdAibaU9jMAzxhknkkAxFE7uVkW' }

--- a/tests/z_integrations/user-flow-1.js
+++ b/tests/z_integrations/user-flow-1.js
@@ -16,7 +16,9 @@ const username = `test-${firstname}${year}`;
 
 const clientOpts = {
   network: fixtures.network,
-  mnemonic: fixtures.mnemonic
+  wallet: {
+    mnemonic: fixtures.mnemonic,
+  },
 };
 describe('Integration - User flow 1 - Identity, DPNS, Documents', function suite() {
   this.timeout(240000);


### PR DESCRIPTION
### Issue being fixed or implemented  

Client options now accept `wallet` parameter of type `Wallet.Options` to introduce a namespace for wallet options. It should now be easier to configure wallet with `privateKey` instead of a `mnemonic` for example or do not initialize it if `wallet` param is not passed.

### What was done  

- Updated `Client` class constructor and `ClientOpts`

### How Has This Been Tested?

Existing tests have been updated and re-runned.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
