### PR TITLE
build: access npm token only when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
   - "10"
   - "12"
 
-before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
 install:
   - npm ci
 
@@ -18,6 +15,10 @@ after_install:
 script:
   - npm run check-package
   - npm run test
+
+before_deploy:
+  # Add token for @dashevo private npm registry
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   - provider: script


### PR DESCRIPTION
### Issue being fixed or implemented  

Currently PRs from external repos cannot successfully run tests because Travis prevents them from accessing the NPM token. 

### What was done  
This attempts to fix that by bypassing token access unless actually deploying (which should only happen from this repo).

### How Has This Been Tested?
This was first implemented on dashevo/dapi-grpc#61. Successfully running tests on this PR is an indication of success.

### Notes  
N/A

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
