### PR TITLE
fix: minified build for NodeJS fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "3.13.0-dev.5",
+  "version": "3.13.0-dev.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "dash",
-  "version": "3.13.0-dev.5",
+  "version": "3.13.0-dev.6",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
-  "main": "dist/dash.cjs.min.js",
+  "main": "dist/dash.cjs.js",
   "unpkg": "dist/dash.min.js",
   "browser": "dist/dash.min.js",
   "types": "dist/src/index.d.ts",

--- a/tests/z_integrations/user-flow-1.js
+++ b/tests/z_integrations/user-flow-1.js
@@ -1,5 +1,5 @@
 const {expect} = require('chai');
-const Dash = require('../../dist/dash.cjs.min.js');
+const Dash = require('../../');
 const Chance = require('chance');
 const chance = new Chance();
 const DataContract = require('@dashevo/dpp/lib/dataContract/DataContract');

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -4,7 +4,7 @@ const baseConfig = {
   entry: './src/index.ts',
   // devtool: 'inline-source-map',
   devtool: 'cheap-module-source-map',
-  // mode: 'development',
+  //mode: 'development',
   mode: "production",
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,13 @@ const es5Config = Object.assign({}, baseConfig, {
   target: 'node',
   // in order to ignore all modules in node_modules folder
   externals: [nodeExternals()],
+  optimization: {
+    minimize: false
+  },
+  devtool: 'inline-source-map',
   output: {
     ...baseConfig.output,
-    filename: 'dash.cjs.min.js',
+    filename: 'dash.cjs.js',
     libraryTarget: 'commonjs2'
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Minified build for NodeJS fails with "u.DAPIClient is not a constructor" 

## What was done?
<!--- Describe your changes in detail -->
Disabled modification for NodeJS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit and integration tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
