### PR TITLE
test: switch for one block confirmation in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "3.13.0-dev.6",
+  "version": "3.13.0-dev.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "3.13.0-dev.6",
+  "version": "3.13.0-dev.7",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "dist/dash.cjs.js",
   "unpkg": "dist/dash.min.js",

--- a/tests/z_integrations/user-flow-1.js
+++ b/tests/z_integrations/user-flow-1.js
@@ -45,7 +45,7 @@ async function fundAddress(dapiClient, faucetAddress, faucetPrivateKey, address,
 
   const transactionId = await dapiClient.sendTransaction(transaction.toBuffer());
 
-  const desiredBlockHeight = currentBlockHeight + 2;
+  const desiredBlockHeight = currentBlockHeight + 1;
 
   do {
     ({ blocks: currentBlockHeight } = await dapiClient.getStatus());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to speed up integration test we could wait just for 1 block after funding address instead of two.

## What was done?
<!--- Describe your changes in detail -->
Reduce the number of blocks to wait during funding in integration tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests in CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
