### PR TITLE
fix: more than one identity registration failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,9 +166,9 @@
       }
     },
     "@dashevo/wallet-lib": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.1.4.tgz",
-      "integrity": "sha512-vzJmTbQ0szRZvVUzuN1y6NBfFMASSue6xZHiZOFvSu8H1Hf8PL+im1edAYceAI3C2gxbo/0Hz+MdezcdK+5udA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.13.0.tgz",
+      "integrity": "sha512-Go0VGciQGvDj+ZGZeB3qifUwgHXvP/e6hEdoQg2tG00fVtGjnEZnuKL6LHQgFGji+h5DxadEWYj3+8OmDef1HA==",
       "requires": {
         "@dashevo/dapi-client": "^0.13.2",
         "@dashevo/dashcore-lib": "^0.18.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@dashevo/dapi-client": "^0.13.2",
     "@dashevo/dashcore-lib": "^0.18.4",
-    "@dashevo/wallet-lib": "7.1.4",
+    "@dashevo/wallet-lib": "7.13.0",
     "@dashevo/dpp": "^0.13.0",
     "bs58": "^4.0.1"
   },

--- a/src/SDK/Client/Client.spec.ts
+++ b/src/SDK/Client/Client.spec.ts
@@ -20,9 +20,14 @@ describe('Dash - Client', function suite() {
     expect(client.wallet).to.be.equal(undefined);
   });
   it('should initiate wallet-lib with a mnemonic', async ()=>{
-    const client = new Client({ wallet: { mnemonic } });
+    const client = new Client({
+      wallet: {
+        mnemonic,
+        offlineMode: true,
+      }
+    });
     expect(client.wallet).to.exist;
-    expect(client.wallet!.offlineMode).to.be.equal(false);
+    expect(client.wallet!.offlineMode).to.be.equal(true);
 
     // @ts-ignore
     await client.wallet.storage.stopWorker();

--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -84,7 +84,7 @@ export class Client {
 
         this.apps = Object.assign({
             dpns: {
-                contractId: '2zjMNfMF31QdunL5SK7DyDULDwXm1PxSqnnSpfBkvTWH'
+                contractId: '7DVe2cDyZMf8sDjQ46XqDzbeGKncrmkD6L96QohLmLbg'
             }
         }, this.options.apps);
 

--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -39,9 +39,9 @@ export default async function createAssetLockTransaction(platform : Platform, fu
     lockTransaction
         .from(selection.utxos)
         // @ts-ignore
-        .to(identityAddressInfo.address, fundingAmount)
-        // @ts-ignore
         .addBurnOutput(output.satoshis, assetLockPublicKey._getID())
+        // @ts-ignore
+        .to(identityAddressInfo.address, fundingAmount)
         // @ts-ignore
         .change(changeAddress)
         .fee(selection.estimatedFee);

--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -1,0 +1,62 @@
+import {PrivateKey, Transaction} from "@dashevo/dashcore-lib";
+import {utils} from "@dashevo/wallet-lib";
+import {Platform} from "./Platform";
+
+export default async function createAssetLockTransaction(platform : Platform, fundingAmount): Promise<{ transaction: Transaction, privateKey: PrivateKey }> {
+    const account = await platform.client.getWalletAccount();
+
+    const identityAddressInfo = account.getUnusedAddress();
+    const [identityHDPrivateKey] = account.getPrivateKeys([identityAddressInfo.address]);
+
+    // @ts-ignore
+    const assetLockPrivateKey = identityHDPrivateKey.privateKey;
+    const assetLockPublicKey = assetLockPrivateKey.toPublicKey();
+
+    const identityAddress = assetLockPublicKey.toAddress(platform.client.network).toString();
+    const changeAddress = account.getUnusedAddress('internal').address;
+
+    const lockTransaction = new Transaction(undefined);
+
+    const output = {
+        satoshis: fundingAmount,
+        address: identityAddress
+    };
+
+    const utxos = account.getUTXOS();
+    const balance = account.getTotalBalance();
+
+    if (balance < output.satoshis) {
+        throw new Error(`Not enough balance (${balance}) to cover burn amount of ${fundingAmount}`);
+    }
+
+    const selection = utils.coinSelection(utxos, [output]);
+
+    // FIXME : Usage with a single utxo had estimated fee of 205.
+    // But network failed us with 66: min relay fee not met.
+    // Over-writing the value for now.
+    selection.estimatedFee = 680;
+
+    lockTransaction
+        .from(selection.utxos)
+        // @ts-ignore
+        .to(identityAddressInfo.address, fundingAmount)
+        // @ts-ignore
+        .addBurnOutput(output.satoshis, assetLockPublicKey._getID())
+        // @ts-ignore
+        .change(changeAddress)
+        .fee(selection.estimatedFee);
+
+    const utxoAddresses = selection.utxos.map((utxo: any) => utxo.address.toString());
+
+    const utxoHDPrivateKey = account.getPrivateKeys(utxoAddresses);
+
+    // @ts-ignore
+    const signingKeys = utxoHDPrivateKey.map((hdprivateKey) => hdprivateKey.privateKey);
+
+    const transaction = lockTransaction.sign(signingKeys);
+
+    return {
+        transaction,
+        privateKey: assetLockPrivateKey
+    };
+}

--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -22,6 +22,12 @@ export default async function createAssetLockTransaction(platform : Platform, fu
         address: identityAddress
     };
 
+    // TODO: Find another way to mark the address as used
+    const outputToMarkItUsed = {
+        satoshis: 10000,
+        address: identityAddress
+    };
+
     const utxos = account.getUTXOS();
     const balance = account.getTotalBalance();
 
@@ -29,7 +35,7 @@ export default async function createAssetLockTransaction(platform : Platform, fu
         throw new Error(`Not enough balance (${balance}) to cover burn amount of ${fundingAmount}`);
     }
 
-    const selection = utils.coinSelection(utxos, [output]);
+    const selection = utils.coinSelection(utxos, [output, outputToMarkItUsed]);
 
     // FIXME : Usage with a single utxo had estimated fee of 205.
     // But network failed us with 66: min relay fee not met.
@@ -41,7 +47,7 @@ export default async function createAssetLockTransaction(platform : Platform, fu
         // @ts-ignore
         .addBurnOutput(output.satoshis, assetLockPublicKey._getID())
         // @ts-ignore
-        .to(identityAddressInfo.address, fundingAmount)
+        .to(identityAddressInfo.address, 10000)
         // @ts-ignore
         .change(changeAddress)
         .fee(selection.estimatedFee);

--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -48,6 +48,7 @@ export default async function createAssetLockTransaction(platform : Platform, fu
 
     const utxoAddresses = selection.utxos.map((utxo: any) => utxo.address.toString());
 
+    // @ts-ignore
     const utxoHDPrivateKey = account.getPrivateKeys(utxoAddresses);
 
     // @ts-ignore

--- a/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/src/SDK/Client/Platform/methods/identities/register.ts
@@ -8,7 +8,7 @@ import createAssetLockTransaction from "../../createAssetLockTransaction";
  * @param {number} [fundingAmount=10000] - funding amount in duffs
  * @returns {Identity}
  */
-export async function register(this: Platform, fundingAmount : number = 10000): Promise<any> {
+export default async function register(this: Platform, fundingAmount : number = 10000): Promise<any> {
     const { client, dpp } = this;
 
     const account = await client.getWalletAccount();
@@ -29,6 +29,7 @@ export async function register(this: Platform, fundingAmount : number = 10000): 
 
     const identityIndex = await account.getUnusedIdentityIndex();
 
+    // @ts-ignore
     const { privateKey: identityPrivateKey } = account.getIdentityHDKeyByIndex(identityIndex, 0)
     const identityPublicKey = identityPrivateKey.toPublicKey();
 

--- a/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/src/SDK/Client/Platform/methods/identities/register.ts
@@ -1,92 +1,43 @@
-import { Transaction } from "@dashevo/dashcore-lib";
-// @ts-ignore
-import {utils} from "@dashevo/wallet-lib";
-
 import {Platform} from "../../Platform";
 import {wait} from "../../../../../utils/wait";
+import createAssetLockTransaction from "../../createAssetLockTransaction";
 
 /**
  * Register identities to the platform
  *
- * @param {Platform} this - bound instance class
+ * @param {number} [fundingAmount=10000] - funding amount in duffs
  * @returns {Identity}
  */
-export async function register(this: Platform): Promise<any> {
+export async function register(this: Platform, fundingAmount : number = 10000): Promise<any> {
     const { client, dpp } = this;
 
     const account = await client.getWalletAccount();
 
-    const burnAmount = 10000;
+    const {
+        transaction: assetLockTransaction,
+        privateKey: assetLockPrivateKey
+    } = await createAssetLockTransaction(this, fundingAmount);
 
-    //TODO : Here, we always use index 0. We might want to increment.
-    // @ts-ignore
-    const identityHDPrivateKey = account.getIdentityHDKey(0);
+    // Broadcast Asset Lock transaction
+    await account.broadcastTransaction(assetLockTransaction.serialize(false));
 
-    // @ts-ignore
-    const identityPrivateKey = identityHDPrivateKey.privateKey;
-    // @ts-ignore
-    const identityPublicKey = identityHDPrivateKey.publicKey;
-
-    // @ts-ignore
-    const identityAddress = identityPublicKey.toAddress().toString();
-    const changeAddress = account.getUnusedAddress('internal').address;
-
-    // @ts-ignore
-    const lockTransaction = new Transaction();
-
-    const output = {
-        satoshis: burnAmount,
-        address: identityAddress
-    };
-
-    const utxos = account.getUTXOS();
-    const balance = account.getTotalBalance();
-
-        if (balance < output.satoshis) {
-            throw new Error(`Not enough balance (${balance}) to cover burn amount of ${burnAmount}`);
-        }
-
-    const selection = utils.coinSelection(utxos, [output]);
-
-    // FIXME : Usage with a single utxo had estimated fee of 205.
-    // But network failed us with 66: min relay fee not met.
-    // Over-writing the value for now.
-    selection.estimatedFee = 680;
-
-    lockTransaction
-        .from(selection.utxos)
-        // @ts-ignore
-        .addBurnOutput(output.satoshis, identityPublicKey._getID())
-        // @ts-ignore
-        .change(changeAddress)
-        .fee(selection.estimatedFee);
-
-    const UTXOHDPrivateKey = account.getPrivateKeys(selection.utxos.map((utxo: any) => utxo.address.toString()));
-
-    // @ts-ignore
-    const signingKeys = UTXOHDPrivateKey.map((hdprivateKey) => hdprivateKey.privateKey);
-
-    // @ts-ignore
-    // FIXME : Seems to fail with addBurnOutput ?
-    // const signedLockTransaction = account.sign(lockTransaction, signingKeys);
-    const signedLockTransaction = lockTransaction.sign(signingKeys);
-
-    // @ts-ignore
-    await account.broadcastTransaction(signedLockTransaction);
-
+    // Wait some time for propagation
     await wait(1000);
 
-    // @ts-ignore
-    const outPoint = signedLockTransaction.getOutPointBuffer(0);
+    // Create Identity
+    const assetLockOutPoint = assetLockTransaction.getOutPointBuffer(0).toString('base64');
 
-    const identity = dpp.identity.create(outPoint, [identityPublicKey]);
+    const identityIndex = await account.getUnusedIdentityIndex();
 
+    const { privateKey: identityPrivateKey } = account.getIdentityHDKeyByIndex(identityIndex, 0)
+    const identityPublicKey = identityPrivateKey.toPublicKey();
+
+    const identity = dpp.identity.create(assetLockOutPoint, [identityPublicKey]);
+
+    // Create ST
     const identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
 
-    // FIXME : Need dpp to be a dependency of wallet-lib to deal with signing IdentityPublicKey (validation)
-    // account.sign(identityPublicKeyModel, identityPrivateKey);
-
-    identityCreateTransition.signByPrivateKey(identityPrivateKey);
+    identityCreateTransition.signByPrivateKey(assetLockPrivateKey);
 
     const result = await dpp.stateTransition.validateStructure(identityCreateTransition);
 
@@ -94,10 +45,9 @@ export async function register(this: Platform): Promise<any> {
         throw new Error(`StateTransition is invalid - ${JSON.stringify(result.getErrors())}`);
     }
 
-    await this.client.getDAPIClient().applyStateTransition(identityCreateTransition);
+    // Broadcast ST
+    await client.getDAPIClient().applyStateTransition(identityCreateTransition);
 
     // @ts-ignore
     return identity;
 }
-
-export default register;

--- a/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/src/SDK/Client/Platform/methods/identities/register.ts
@@ -19,7 +19,8 @@ export default async function register(this: Platform, fundingAmount : number = 
     } = await createAssetLockTransaction(this, fundingAmount);
 
     // Broadcast Asset Lock transaction
-    await account.broadcastTransaction(assetLockTransaction.serialize(false));
+    // @ts-ignore
+    await account.broadcastTransaction(assetLockTransaction);
 
     // Wait some time for propagation
     await wait(1000);
@@ -48,6 +49,14 @@ export default async function register(this: Platform, fundingAmount : number = 
 
     // Broadcast ST
     await client.getDAPIClient().applyStateTransition(identityCreateTransition);
+
+    // @ts-ignore
+    account.storage.insertIdentityIdAtIndex(
+        // @ts-ignore
+        account.walletId,
+        identity.getId(),
+        identityIndex,
+    );
 
     // @ts-ignore
     return identity;

--- a/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/src/SDK/Client/Platform/methods/identities/register.ts
@@ -25,7 +25,7 @@ export async function register(this: Platform, fundingAmount : number = 10000): 
     await wait(1000);
 
     // Create Identity
-    const assetLockOutPoint = assetLockTransaction.getOutPointBuffer(0).toString('base64');
+    const assetLockOutPoint = assetLockTransaction.getOutPointBuffer(0);
 
     const identityIndex = await account.getUnusedIdentityIndex();
 

--- a/src/SDK/Client/Platform/methods/identities/topUp.ts
+++ b/src/SDK/Client/Platform/methods/identities/topUp.ts
@@ -22,7 +22,8 @@ export async function topUp(this: Platform, identityId: string, amount: number):
     } = await createAssetLockTransaction(this, amount);
 
     // Broadcast Asset Lock transaction
-    await account.broadcastTransaction(assetLockTransaction.serialize(false));
+    // @ts-ignore
+    await account.broadcastTransaction(assetLockTransaction);
 
     // Wait some time for propagation
     await wait(1000);

--- a/src/SDK/Client/Platform/methods/identities/topUp.ts
+++ b/src/SDK/Client/Platform/methods/identities/topUp.ts
@@ -1,10 +1,7 @@
-import { Transaction } from "@dashevo/dashcore-lib";
-// @ts-ignore
-import {utils} from "@dashevo/wallet-lib";
-
 import {Platform} from "../../Platform";
 
 import { wait } from "../../../../../utils/wait";
+import createAssetLockTransaction from "../../createAssetLockTransaction";
 
 /**
  * Register identities to the platform
@@ -19,74 +16,25 @@ export async function topUp(this: Platform, identityId: string, amount: number):
 
     const account = await client.getWalletAccount();
 
-    // TODO: this key needs to be incremented, but there's no agreement on how to derived it currently
-    // @ts-ignore
-    const identityHDPrivateKey = account.getIdentityHDKey(0);
+    const {
+        transaction: assetLockTransaction,
+        privateKey: assetLockPrivateKey
+    } = await createAssetLockTransaction(this, amount);
 
-    // @ts-ignore
-    const identityPrivateKey = identityHDPrivateKey.privateKey;
-    // @ts-ignore
-    const identityPublicKey = identityHDPrivateKey.publicKey;
+    // Broadcast Asset Lock transaction
+    await account.broadcastTransaction(assetLockTransaction.serialize(false));
 
-    // @ts-ignore
-    const identityAddress = identityPublicKey.toAddress().toString();
-    const changeAddress = account.getUnusedAddress('internal').address;
-
-    let selection;
-    // @ts-ignore
-    const lockTransaction = new Transaction();
-
-    const output = {
-        satoshis: amount,
-        address: identityAddress
-    };
-
-    const utxos = account.getUTXOS();
-    const balance = account.getTotalBalance();
-
-    if (balance < output.satoshis) {
-        throw new Error(`Not enough balance (${balance}) to cover burn amount of ${amount}`)
-    }
-
-    selection = utils.coinSelection(utxos, [output]);
-
-    // FIXME : Usage with a single utxo had estimated fee of 205.
-    // But network failed us with 66: min relay fee not met.
-    // Over-writing the value for now.
-    selection.estimatedFee = 680;
-
-    lockTransaction
-        .from(selection.utxos)
-        // @ts-ignore
-        .addBurnOutput(output.satoshis, identityPublicKey._getID())
-        // @ts-ignore
-        .change(changeAddress)
-        .fee(selection.estimatedFee);
-
-    const UTXOHDPrivateKey = account.getPrivateKeys(selection.utxos.map((utxo: any) => utxo.address.toString()));
-
-    // @ts-ignore
-    const signingKeys = UTXOHDPrivateKey.map((hdprivateKey) => hdprivateKey.privateKey);
-
-    // @ts-ignore
-    // FIXME : Seems to fail with addBurnOutput ?
-    // const signedLockTransaction = account.sign(lockTransaction, signingKeys);
-    const signedLockTransaction = lockTransaction.sign(signingKeys);
-
-    // @ts-ignore
-    await account.broadcastTransaction(signedLockTransaction);
-
+    // Wait some time for propagation
     await wait(1000);
 
+    // Create ST
+
     // @ts-ignore
-    const outPointBuffer = signedLockTransaction.getOutPointBuffer(0);
+    const outPointBuffer = assetLockTransaction.getOutPointBuffer(0);
 
     const identityTopUpTransition = dpp.identity.createIdentityTopUpTransition(identityId, outPointBuffer);
 
-    // FIXME : Need dpp to be a dependency of wallet-lib to deal with signing IdentityPublicKey (validation)
-    // account.sign(identityPublicKeyModel, identityPrivateKey);
-
-    identityTopUpTransition.signByPrivateKey(identityPrivateKey);
+    identityTopUpTransition.signByPrivateKey(assetLockPrivateKey);
 
     const result = await dpp.stateTransition.validateStructure(identityTopUpTransition);
 
@@ -94,9 +42,8 @@ export async function topUp(this: Platform, identityId: string, amount: number):
         throw new Error(`StateTransition is invalid - ${JSON.stringify(result.getErrors())}`);
     }
 
-    const dapiClient = this.client.getDAPIClient();
-
-    await dapiClient.applyStateTransition(identityTopUpTransition);
+    // Broadcast ST
+    await client.getDAPIClient().applyStateTransition(identityTopUpTransition);
 
     // @ts-ignore
     return true;

--- a/tests/functional/sdk.js
+++ b/tests/functional/sdk.js
@@ -164,6 +164,8 @@ describe('SDK', function suite() {
       throw new Error('Can\'t perform the test. Failed to create identity');
     }
 
+    await wait(200);
+
     const fetchIdentity = await clientInstance.platform.identities.get(createdIdentityId);
 
     expect(fetchIdentity).to.exist;

--- a/tests/functional/sdk.js
+++ b/tests/functional/sdk.js
@@ -102,7 +102,7 @@ describe('SDK', function suite() {
   });
 
   it('should sign and verify a message', async function () {
-    const idKey = account.getIdentityHDKey();
+    const idKey = account.getIdentityHDKeyByIndex(0, 0);
     // This transforms from a Wallet-Lib.PrivateKey to a Dashcore-lib.PrivateKey.
     // It will quickly be annoying to perform this, and we therefore need to find a better solution for that.
     const privateKey = Dash.Core.PrivateKey(idKey.privateKey);

--- a/tests/functional/sdk.js
+++ b/tests/functional/sdk.js
@@ -146,11 +146,7 @@ describe('SDK', function suite() {
       throw new Error('Insufficient balance to perform this test')
     }
 
-    try {
-      createdIdentity = await clientInstance.platform.identities.register();
-    } catch (e) {
-      console.dir(e, { depth: 100 })
-    }
+    createdIdentity = await clientInstance.platform.identities.register();
 
     createdIdentityId = createdIdentity.getId();
 

--- a/tests/functional/sdk.js
+++ b/tests/functional/sdk.js
@@ -123,7 +123,7 @@ describe('SDK', function suite() {
       faucetAddress,
       faucetPrivateKey,
       account.getAddress().address,
-      50000
+      100000
     )
   })
 
@@ -146,7 +146,11 @@ describe('SDK', function suite() {
       throw new Error('Insufficient balance to perform this test')
     }
 
-    createdIdentity = await clientInstance.platform.identities.register();
+    try {
+      createdIdentity = await clientInstance.platform.identities.register();
+    } catch (e) {
+      console.dir(e, { depth: 100 })
+    }
 
     createdIdentityId = createdIdentity.getId();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More than one call of `Client#identities.register` failed because SDK uses always the same private key.

## What was done?
<!--- Describe your changes in detail -->
- Get new unused private key for identity registration
- Sign asset lock transaction with a separate private key
- Update DPNS contract ID
- Use correct Identity private key for singing STs
- Enable ST validation before broadcasting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit and functional tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
