### PR TITLE
fix: wrong assetlock tx fee estimation

### DIFF
--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -37,11 +37,6 @@ export default async function createAssetLockTransaction(platform : Platform, fu
 
     const selection = utils.coinSelection(utxos, [output, outputToMarkItUsed]);
 
-    // FIXME : Usage with a single utxo had estimated fee of 205.
-    // But network failed us with 66: min relay fee not met.
-    // Over-writing the value for now.
-    selection.estimatedFee = 680;
-
     lockTransaction
         .from(selection.utxos)
         // @ts-ignore
@@ -50,7 +45,6 @@ export default async function createAssetLockTransaction(platform : Platform, fu
         .to(identityAddressInfo.address, 10000)
         // @ts-ignore
         .change(changeAddress)
-        .fee(selection.estimatedFee);
 
     const utxoAddresses = selection.utxos.map((utxo: any) => utxo.address.toString());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Error with 'min relay fee not met' when registering/topping up an identity

## What was done?
<!--- Describe your changes in detail -->
Remove fee estimation from `createAssetLockTransaction` and fallback on the default estimation algorithm

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run existing tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
