### PR TITLE
fix: generate one-time private key for the asset lock transaction

### DIFF
--- a/src/SDK/Client/Platform/createAssetLockTransaction.ts
+++ b/src/SDK/Client/Platform/createAssetLockTransaction.ts
@@ -2,29 +2,27 @@ import {PrivateKey, Transaction} from "@dashevo/dashcore-lib";
 import {utils} from "@dashevo/wallet-lib";
 import {Platform} from "./Platform";
 
+/**
+ * Creates a funding transaction for the platform identity and returns one-time key to sign the state transition
+ * @param {Platform} platform
+ * @param {number} fundingAmount - amount of dash to fund the identity's credits
+ * @return {{transaction: Transaction, privateKey: PrivateKey}} - transaction and one time private key
+ * that can be used to sign registration/top-up state transition
+ */
 export default async function createAssetLockTransaction(platform : Platform, fundingAmount): Promise<{ transaction: Transaction, privateKey: PrivateKey }> {
     const account = await platform.client.getWalletAccount();
 
-    const identityAddressInfo = account.getUnusedAddress();
-    const [identityHDPrivateKey] = account.getPrivateKeys([identityAddressInfo.address]);
-
     // @ts-ignore
-    const assetLockPrivateKey = identityHDPrivateKey.privateKey;
-    const assetLockPublicKey = assetLockPrivateKey.toPublicKey();
+    const assetLockOneTimePrivateKey = new PrivateKey();
+    const assetLockOneTimePublicKey = assetLockOneTimePrivateKey.toPublicKey();
 
-    const identityAddress = assetLockPublicKey.toAddress(platform.client.network).toString();
+    const identityAddress = assetLockOneTimePublicKey.toAddress(platform.client.network).toString();
     const changeAddress = account.getUnusedAddress('internal').address;
 
     const lockTransaction = new Transaction(undefined);
 
     const output = {
         satoshis: fundingAmount,
-        address: identityAddress
-    };
-
-    // TODO: Find another way to mark the address as used
-    const outputToMarkItUsed = {
-        satoshis: 10000,
         address: identityAddress
     };
 
@@ -35,14 +33,12 @@ export default async function createAssetLockTransaction(platform : Platform, fu
         throw new Error(`Not enough balance (${balance}) to cover burn amount of ${fundingAmount}`);
     }
 
-    const selection = utils.coinSelection(utxos, [output, outputToMarkItUsed]);
+    const selection = utils.coinSelection(utxos, [output]);
 
     lockTransaction
         .from(selection.utxos)
         // @ts-ignore
-        .addBurnOutput(output.satoshis, assetLockPublicKey._getID())
-        // @ts-ignore
-        .to(identityAddressInfo.address, 10000)
+        .addBurnOutput(output.satoshis, assetLockOneTimePublicKey._getID())
         // @ts-ignore
         .change(changeAddress)
 
@@ -58,6 +54,6 @@ export default async function createAssetLockTransaction(platform : Platform, fu
 
     return {
         transaction,
-        privateKey: assetLockPrivateKey
+        privateKey: assetLockOneTimePrivateKey
     };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generate a one-time private key for identity registration and top-up sts instead of using one from the wallet

## What was done?
<!--- Describe your changes in detail -->
Made `createAssetLockTransaction` generate a new one-time private key every time a new asset lock transaction is created; Removed sending small amount of wallet funds to the address associated with the key to prevent it from getting reused.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
