### PR TITLE
fix(npm): Allow npm install from forked github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:browsers": "karma start ./karma.conf.js --single-run",
     "test:unit": "mocha -r ts-node/register \"src/**/*.spec.ts\"",
     "test:functional": "npm run build && mocha --recursive tests/functional/**/*.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fixes #100 by adding a `prepare` script to `package.json` running `npm run build` upon installing from a forked github repo.

