### PR TITLE
feat(documents): Allow to retrieve a document by its ID

### DIFF
--- a/src/SDK/Client/Platform/Platform.ts
+++ b/src/SDK/Client/Platform/Platform.ts
@@ -6,6 +6,7 @@ import Client, { ClientApps } from "../Client";
 import broadcastDocument from "./methods/documents/broadcast";
 import createDocument from "./methods/documents/create";
 import getDocument from "./methods/documents/get";
+import getDocumentById from "./methods/documents/getById";
 
 import broadcastContract from "./methods/contracts/broadcast";
 import createContract from "./methods/contracts/create";
@@ -37,11 +38,13 @@ export interface PlatformOpts {
  * @param {Function} broadcast - broadcast records onto the platform
  * @param {Function} create - create records which can be broadcasted
  * @param {Function} get - get records from the platform
+ * @param {Function} getById - get records by id from the platform
  */
 interface Records {
     broadcast: Function,
     create: Function,
     get: Function,
+    getById?: Function,
 }
 
 /**
@@ -77,6 +80,7 @@ export class Platform {
     public documents: Records;
     /**
      * @param {Function} get - get identities from the platform
+     * @param {Function} getById - get document by id from the platform
      * @param {Function} register - register identities on the platform
      */
     public identities: Identities;
@@ -106,6 +110,7 @@ export class Platform {
             broadcast: broadcastDocument.bind(this),
             create: createDocument.bind(this),
             get: getDocument.bind(this),
+            getById: getDocumentById.bind(this),
         };
         this.contracts = {
             broadcast: broadcastContract.bind(this),

--- a/src/SDK/Client/Platform/methods/documents/getById.ts
+++ b/src/SDK/Client/Platform/methods/documents/getById.ts
@@ -1,0 +1,20 @@
+import {Platform} from "../../Platform";
+
+/**
+ * Get names from the platform
+ * @param {Platform} this - bound instance class
+ * @param {string} typeLocator type locator
+ * @param {string} id - id
+ * @returns documents
+ */
+export async function getById(this: Platform, typeLocator: string, id: string): Promise<any> {
+    const queryOpts = {
+        where: [
+            ['$id', '==', id]
+        ],
+    };
+    const documents = await this.documents.get(typeLocator, queryOpts);
+    return (documents[0] !== undefined) ? documents[0] : null;
+};
+
+export default getById;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Add shorthand method to retrieve documents by their `$id`

Example:

```
    const document = await client.platform.documents.getById(
      'PaymentRequest.PaymentIntent',
      'DD9yD2G63GPdwcQi987tmiCeL3YybGDmXLkQr1jBLPhm'
    );
```


closes #102 